### PR TITLE
Configurable Client ID generator function

### DIFF
--- a/src/oidcop/oidc/registration.py
+++ b/src/oidcop/oidc/registration.py
@@ -22,7 +22,7 @@ from oidcop.endpoint import Endpoint
 from oidcop.exception import CapabilitiesMisMatch
 from oidcop.exception import InvalidRedirectURIError
 from oidcop.exception import InvalidSectorIdentifier
-from oidcop.util import split_uri
+from oidcop.util import split_uri, importer
 
 PREFERENCE2PROVIDER = {
     # "require_signed_request_object": "request_object_algs_supported",
@@ -116,6 +116,17 @@ def comb_uri(args):
                 val.append(base)
         args['request_uris'] = val
 
+
+def random_client_id(length:int=16, reserved:list=[]):
+    # create new id och secret
+    client_id = rndstr(16)
+    # cdb client_id MUST be unique!
+    while client_id in reserved:
+        client_id = rndstr(16)
+    return client_id
+
+def ciao(length:int=16, reserved:list=[]):
+    return 'suka'
 
 class Registration(Endpoint):
     request_cls = RegistrationRequest
@@ -393,12 +404,14 @@ class Registration(Endpoint):
             )
 
         _context = self.server_get("endpoint_context")
+        cid_generator = importer(
+            self.kwargs.get('client_id_generator',
+                            'oidcop.oidc.registration.random_client_id'
+            ),
+        )
+
         if new_id:
-            # create new id och secret
-            client_id = rndstr(12)
-            # cdb client_id MUST be unique!
-            while client_id in _context.cdb:
-                client_id = rndstr(12)
+            client_id = cid_generator(reserved=_context.cdb.keys())
             if "client_id" in request:
                 del request["client_id"]
         else:


### PR DESCRIPTION
A custom Client ID generator function can be defined Registration endpoint configuration

* feat: "client_id_generator"
* feat: default client_id length up to 16 digits

````
    "registration": {
      "path": "registration",
      "class": "oidcop.oidc.registration.Registration",
      "kwargs": {
        "client_authn_method": None,
        "client_secret_expiration_time": 432000,
        "client_id_generator": 'oidcop.oidc.registration.random_client_id'
      }
````