### PR TITLE
feat: additional check on session db consistency

### DIFF
--- a/src/oidcop/session/database.py
+++ b/src/oidcop/session/database.py
@@ -28,6 +28,10 @@ class NoSuchGrant(KeyError):
     pass
 
 
+class InconsistentDatabase(TypeError):
+    pass
+
+
 class Database(ImpExp):
     parameter = {
         "db": DLDict,
@@ -91,6 +95,8 @@ class Database(ImpExp):
             user_info = self.db[uid]
         except KeyError:
             raise KeyError('No such UserID')
+        except TypeError:
+            raise InconsistentDatabase('Missing session db')
         else:
             if user_info is None:
                 raise KeyError('No such UserID')


### PR DESCRIPTION
I'm facing a database inconsistency after the first, succesfull, RP session accomplished.
the second call fails because of a inconsistent database.

Now I just push here a check with a message that hints about this problem