### PR TITLE
feat: added required access token claims

### DIFF
--- a/src/oidcop/session/grant.py
+++ b/src/oidcop/session/grant.py
@@ -172,8 +172,17 @@ class Grant(Item):
 
         payload = {
             "scope": scope,
-            "aud": self.resources
+            "aud": self.resources,
+            "jti" : uuid1().hex
         }
+
+        if self.authorization_request:
+            client_id = self.authorization_request.get('client_id')
+            if client_id:
+                payload.update({
+                    "client_id": client_id,
+                    'sub': client_id
+                })
 
         _claims_restriction = endpoint_context.claims_interface.get_claims(session_id,
                                                                            scopes=scope,
@@ -232,11 +241,12 @@ class Grant(Item):
                 token_handler = endpoint_context.session_manager.token_handler.handler[
                     GRANT_TYPE_MAP[token_type]]
 
+            token_payload = self.payload_arguments(session_id,
+                                                   endpoint_context,
+                                                   token_type=token_type,
+                                                   scope=scope)
             item.value = token_handler(session_id=session_id,
-                                       **self.payload_arguments(session_id,
-                                                                endpoint_context,
-                                                                token_type=token_type,
-                                                                scope=scope))
+                                       **token_payload)
         else:
             raise ValueError("Can not mint that kind of token")
 

--- a/src/oidcop/token/jwt_token.py
+++ b/src/oidcop/token/jwt_token.py
@@ -48,6 +48,10 @@ class JWTToken(Token):
         self.def_aud = aud or []
         self.alg = alg
 
+    def load_claims(self, payload:dict={}):
+        # inherit me and do your things here
+        return payload
+
     def __call__(self,
                  session_id: Optional[str] = '',
                  ttype: Optional[str] = '',
@@ -66,7 +70,12 @@ class JWTToken(Token):
         else:
             ttype = "A"
 
-        payload.update({"sid": session_id, "ttype": ttype})
+        payload.update(
+            {"sid": session_id,
+             "ttype": ttype
+            }
+        )
+        payload = self.load_claims(payload)
 
         # payload.update(kwargs)
         signer = JWT(


### PR DESCRIPTION
This PR fixes this https://github.com/IdentityPython/oidc-op/issues/34

it also adds a custom method in jwt_token called `load_custom_claims` that helpds developers to opportunely customize claims, if needed

if accepted this method MUST be documented 