### PR TITLE
construct_endpoint_info

### DIFF
--- a/src/oidcop/endpoint.py
+++ b/src/oidcop/endpoint.py
@@ -123,7 +123,6 @@ class Endpoint(object):
             _methods = self.default_capabilities.get("client_authn_method")
             if _methods:
                 self.client_authn_method = client_auth_setup(_methods, server_get)
-
         self.endpoint_info = construct_endpoint_info(
             self.default_capabilities, **kwargs
         )


### PR DESCRIPTION
this PR helped understanding a weakness in the general configuration manager, used to put default capabilities and get it in provider-discovery json response BUT these paramenters doesn't really changed the endpoints behaviour.

With this approach I got several benefits, also did:

- chore: general refactor
- feat: WEAK algorithms makes a warning message in logs

this commit addresses https://github.com/IdentityPython/oidc-op/issues/22
