### PR TITLE
jwks factory

### DIFF
--- a/src/oidcop/token/handler.py
+++ b/src/oidcop/token/handler.py
@@ -139,27 +139,53 @@ def factory(server_get,
     TTYPE = {"code": "A", "token": "T", "refresh": "R"}
 
     key_defs = []
-    if code is not None:
-        key_defs.append({"type": "oct", "bytes": 24, "use": ["enc"], "kid": "code"})
-    if refresh is not None:
-        key_defs.append({"type": "oct", "bytes": 24, "use": ["enc"], "kid": "refresh"})
-    if token is not None:
-        key_defs.append({"type": "oct", "bytes": 24, "use": ["enc"], "kid": "token"})
+    read_only = False
+    if kwargs.get('jwks_def'):
+        defs = kwargs['jwks_def']
+        jwks_file = defs.get('private_path', jwks_file)
+        read_only = defs.get('read_only', read_only)
+        key_defs = defs.get('key_defs', [])
 
-    kj = init_key_jar(key_defs=key_defs, private_path=jwks_file, read_only=False)
+    for _keyd in key_defs:
+        if _keyd['kid'] == 'code':
+            code = _keyd
+        elif _keyd['kid'] == 'refresh':
+            refresh = _keyd
+        elif _keyd['kid'] == 'token':
+            token = _keyd
+
+    if code is not None:
+        key_defs.append(
+            {"type": "oct", "bytes": 24, "use": ["enc"], "kid": "code"}
+        )
+    if refresh is not None:
+        key_defs.append(
+            {"type": "oct", "bytes": 24, "use": ["enc"], "kid": "refresh"}
+        )
+    if token is not None:
+        key_defs.append(
+            {"type": "oct", "bytes": 24, "use": ["enc"], "kid": "token"}
+        )
+
+    kj = init_key_jar(key_defs=key_defs, private_path=jwks_file, read_only=read_only)
 
     args = {}
-
     if code:
         _add_passwd(kj, code, "code")
-        args["code_handler"] = init_token_handler(server_get, code, TTYPE["code"])
+        args["code_handler"] = init_token_handler(
+            server_get, code, TTYPE["code"]
+        )
 
     if token:
         _add_passwd(kj, token, "token")
-        args["access_token_handler"] = init_token_handler(server_get, token, TTYPE["token"])
+        args["access_token_handler"] = init_token_handler(
+            server_get, token, TTYPE["token"]
+        )
 
     if refresh is not None:
         _add_passwd(kj, refresh, "refresh")
-        args["refresh_token_handler"] = init_token_handler(server_get, refresh, TTYPE["refresh"])
+        args["refresh_token_handler"] = init_token_handler(
+            server_get, refresh, TTYPE["refresh"]
+        )
 
     return TokenHandler(**args)


### PR DESCRIPTION
- fix: factory creates two different folder even If a private_path was defined in the general configuration
- chore: small code refactor with linting

With this PR now I have a clean base directory.
I configured custom folders where to store private and public files, but oidc-op still creates a private/token_jwks.json as a duplicate of which i configured with the custom private_path.

digging in the code I found what it could be a silly bug, now it's fixed