### PR TITLE
chore: token dumps tests

### DIFF
--- a/example/flask_op/config.json
+++ b/example/flask_op/config.json
@@ -361,7 +361,7 @@
           }
         },
         "id_token": {
-          "class": "oidcop.id_token.IDToken",
+          "class": "oidcop.token.id_token.IDToken",
           "kwargs": {
             "default_claims": {
               "email": {

--- a/tests/test_01_session_token.py
+++ b/tests/test_01_session_token.py
@@ -2,6 +2,7 @@ from oidcmsg.time_util import time_sans_frac
 
 from oidcop.session.token import AccessToken
 from oidcop.session.token import AuthorizationCode
+from oidcop.session.token import IDToken
 
 
 def test_authorization_code_default():
@@ -36,22 +37,34 @@ def test_authorization_code_extras():
     assert code.resources == ["https://api.example.com"]
 
 
-def test_dump_load():
-    code = AuthorizationCode(
-        value="ABCD",
-        scope=["openid", "foo", "bar"],
-        claims={"userinfo": {"given_name": None}},
-        resources=["https://api.example.com"],
-    )
+def test_dump_load(cls=AuthorizationCode,
+                   kwargs=dict(
+                        value="ABCD",
+                        scope=["openid", "foo", "bar"],
+                        claims={"userinfo": {"given_name": None}},
+                        resources=["https://api.example.com"],
+                    )
+    ):
+    code = cls(**kwargs)
 
     _item = code.dump()
-
-    _new_code = AuthorizationCode().load(_item)
-
-    for attr in AuthorizationCode.parameter.keys():
+    _new_code = cls().load(_item)
+    for attr in cls.parameter.keys():
         val = getattr(code, attr)
         if val:
             assert val == getattr(_new_code, attr)
+
+def test_dump_load_access_token():
+    test_dump_load(
+        cls=AccessToken,
+        kwargs={}
+    )
+
+def test_dump_load_idtoken():
+    test_dump_load(
+        cls=IDToken,
+        kwargs={}
+    )
 
 
 def test_supports_minting():

--- a/tests/test_05_id_token.py
+++ b/tests/test_05_id_token.py
@@ -201,7 +201,7 @@ class TestEndpoint(object):
         )
 
     def _mint_access_token(self, grant, session_id, token_ref):
-        return grant.mint_token(
+        access_token = grant.mint_token(
             session_id=session_id,
             endpoint_context=self.endpoint_context,
             token_type="access_token",
@@ -209,6 +209,7 @@ class TestEndpoint(object):
             expires_at=time_sans_frac() + 900,  # 15 minutes from now
             based_on=token_ref,  # Means the token (tok) was used to mint this token
         )
+        return access_token
 
     def _mint_id_token(
         self, grant, session_id, token_ref=None, code=None, access_token=None


### PR DESCRIPTION
fix: flaskop example 
feat: added dump tests for access_token and id_token