### PR TITLE
BREAKAGE: configuration's password, salt and sub_funcs now are under session_params

### DIFF
--- a/doc/source/contents/conf.rst
+++ b/doc/source/contents/conf.rst
@@ -15,18 +15,49 @@ seed
 Used in dynamic client registration endpoint when creating a new client_secret.
 If unset it will be random.
 
---------
+--------------
+session params
+--------------
+
+Configuration parameters used by session manager
+
+    "session_params": {
+      "password": "__password_used_to_encrypt_access_token_sid_value",
+      "salt": "salt involved in session sub hash ",
+      "sub_func": {
+        "public": {
+          "class": "oidcop.session.manager.PublicID",
+          "kwargs": {
+            "salt": "sdfsdfdsf"
+          }
+        },
+        "pairwise": {
+          "class": "oidcop.session.manager.PairWiseID",
+          "kwargs": {
+            "salt": "sdfsdfsdf"
+          }
+        }
+     }
+  },
+
 password
---------
+########
 
 Encryption key used to encrypt the SessionID (sid) in access_token.
 If unset it will be random.
 
-----
+
 salt
-----
+####
 
 Salt, value or filename, used in sub_funcs (pairwise, public) for creating the opaque hash of *sub* claim.
+
+
+sub_funcs
+#########
+
+Functions involved in subject creation (jwt token sub claim).
+
 
 -----------
 session_key

--- a/src/oidcop/configure.py
+++ b/src/oidcop/configure.py
@@ -220,8 +220,7 @@ class EntityConfiguration(Base):
         self.template_dir = None
         self.token_handler_args = {}
         self.userinfo = None
-        self.password = None
-        self.salt = None
+        self.session_params = None
 
         if file_attributes is None:
             file_attributes = DEFAULT_FILE_ATTRIBUTE_NAMES
@@ -268,7 +267,6 @@ class OPConfiguration(EntityConfiguration):
         self.id_token = None
         self.login_hint2acrs = {}
         self.login_hint_lookup = None
-        self.sub_func = {}
 
         EntityConfiguration.__init__(self, conf=conf, base_path=base_path,
                                      entity_conf=entity_conf, domain=domain, port=port,

--- a/src/oidcop/endpoint_context.py
+++ b/src/oidcop/endpoint_context.py
@@ -292,8 +292,9 @@ class EndpointContext(OidcContext):
 
         :return: string
         """
-        _conf = self.conf.get("sub_func", {})
-        for key, args in _conf.items():
+        ses_par = self.conf.get("session_params") or {}
+        sub_func = ses_par.get("sub_func") or {}
+        for key, args in sub_func.items():
             if "class" in args:
                 self._sub_func[key] = init_service(args)
             elif "function" in args:

--- a/src/oidcop/session/manager.py
+++ b/src/oidcop/session/manager.py
@@ -77,8 +77,9 @@ class SessionManager(Database):
         self.conf = conf or {}
 
         # these won't change runtime
-        self._key = self.conf.get("password") or rndstr(24)
-        self._salt = self.conf.get("salt") or rndstr(32)
+        session_params = self.conf.get("session_params") or {}
+        self._key = session_params.get("password") or rndstr(24)
+        self._salt = session_params.get("salt") or rndstr(32)
 
         self.key = self.load_key()
         self.salt = self.load_key()

--- a/tests/op_config.json
+++ b/tests/op_config.json
@@ -273,19 +273,23 @@
     "type": "OCT",
     "use": "sig"
   },
-  "sub_func": {
-    "public": {
-      "class": "oidcop.session.manager.PublicID",
-      "kwargs": {
-        "filename": "public.salt"
-      }
-    },
-    "pairwise": {
-      "class": "oidcop.session.manager.PairWiseID",
-      "kwargs": {
-        "filename": "pairwise.salt"
-      }
-    }
+  "session_params": {
+      "password": "__password_used_to_encrypt_access_token_sid_value",
+      "salt": "salt involved in session sub hash ",
+      "sub_func": {
+        "public": {
+          "class": "oidcop.session.manager.PublicID",
+          "kwargs": {
+            "salt": "sdfsdfdsf"
+          }
+        },
+        "pairwise": {
+          "class": "oidcop.session.manager.PairWiseID",
+          "kwargs": {
+            "salt": "sdfsdfsdf"
+          }
+        }
+     }
   },
   "template_dir": "templates",
   "token_handler_args": {


### PR DESCRIPTION
With this PR we have this new configuration parameter called "session_params" that contains all the paramenters involved in session management configuration.

````
  "session_params": {
      "password": "__password_used_to_encrypt_access_token_sid_value",
      "salt": "salt involved in session sub hash ",
      "sub_func": {
        "public": {
          "class": "oidcop.session.manager.PublicID",
          "kwargs": {
            "salt": "sdfsdfdsf"
          }
        },
        "pairwise": {
          "class": "oidcop.session.manager.PairWiseID",
          "kwargs": {
            "salt": "sdfsdfsdf"
          }
        }
     }
  },
````

this PR fixes https://github.com/IdentityPython/oidc-op/issues/60
@rohe I know that's something for 2.1.0 release but believe me, I couldn't resist, it was very easy to be implemented :)