### PR TITLE
BREAKAGE: seed param moved from global configuration to registration endoint

### DIFF
--- a/doc/source/contents/conf.rst
+++ b/doc/source/contents/conf.rst
@@ -8,12 +8,6 @@ issuer
 
 The issuer ID of the OP, a unique value in URI format.
 
-----
-seed
-----
-
-Used in dynamic client registration endpoint when creating a new client_secret.
-If unset it will be random.
 
 --------
 password
@@ -209,8 +203,14 @@ An example::
           "path": "registration",
           "class": "oidcop.oidc.registration.Registration",
           "kwargs": {
-            "client_authn_method": null,
-            "client_secret_expiration_time": 432000
+            "client_authn_method": None,
+            "client_secret_expiration_time": 432000,
+            "client_id_generator": {
+               "class": 'oidcop.oidc.registration.random_client_id',
+               "kwargs": {
+                    "seed": "that-optional-random-value"
+               }
+           }
           }
         },
         "registration_api": {

--- a/src/oidcop/configure.py
+++ b/src/oidcop/configure.py
@@ -221,7 +221,6 @@ class EntityConfiguration(Base):
         self.token_handler_args = {}
         self.userinfo = None
         self.password = None
-        self.salt = None
 
         if file_attributes is None:
             file_attributes = DEFAULT_FILE_ATTRIBUTE_NAMES

--- a/src/oidcop/endpoint_context.py
+++ b/src/oidcop/endpoint_context.py
@@ -6,7 +6,6 @@ from typing import Union
 
 import requests
 from cryptojwt import KeyJar
-from cryptojwt.utils import as_bytes
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
 from oidcmsg.context import OidcContext
@@ -111,7 +110,6 @@ class EndpointContext(OidcContext):
         "provider_info": {},
         "registration_access_token": {},
         "scope2claims": {},
-        "seed": "",
         # "session_db": {},
         "session_manager": SessionManager,
         "sso_ttl": None,
@@ -138,12 +136,6 @@ class EndpointContext(OidcContext):
         # self.session_db = {}
 
         self.cwd = cwd
-
-        # Those that use seed wants bytes but I can only store str.
-        try:
-            self.seed = as_bytes(conf["seed"])
-        except KeyError:
-            self.seed = as_bytes(rndstr(32))
 
         # Default values, to be changed below depending on configuration
         # arguments for endpoints add-ons


### PR DESCRIPTION
this definitely closes 
https://github.com/IdentityPython/oidc-op/issues/60

now we have the seed parameter as a Registration endpoint internal parameter

````
    "registration": {
      "path": "registration",
      "class": "oidcop.oidc.registration.Registration",
      "kwargs": {
        "client_authn_method": None,
        "client_secret_expiration_time": 432000,
        "client_id_generator": {
           "class": 'oidcop.oidc.registration.random_client_id',
           "kwargs": {
                "seed": "that-optional-random-value"
           }
       }
      }
    },
````