### PR TITLE
Make id token lifetime configurable

### DIFF
--- a/src/oidcop/token/id_token.py
+++ b/src/oidcop/token/id_token.py
@@ -25,7 +25,6 @@ DEF_SIGN_ALG = {
     "client_secret_jwt": "HS256",
     "private_key_jwt": "RS256",
 }
-DEF_LIFETIME = 300
 
 
 def include_session_id(endpoint_context, client_id, where):
@@ -241,7 +240,7 @@ class IDToken(Token):
         )
 
         if lifetime is None:
-            lifetime = DEF_LIFETIME
+            lifetime = self.lifetime
 
         _jwt = JWT(_context.keyjar, iss=_context.issuer, lifetime=lifetime, **alg_dict)
 
@@ -261,7 +260,7 @@ class IDToken(Token):
         else:
             xargs = {}
 
-        lifetime = self.kwargs.get("lifetime")
+        lifetime = self.lifetime
 
         # Weed out stuff that doesn't belong here
         kwargs = {k: v for k, v in kwargs.items() if k in ["encrypt", "code", "access_token"]}


### PR DESCRIPTION
Seems like this was broken when id token handling was moved to the token handler