### PR TITLE
Allow requesting for scopes in refresh

### DIFF
--- a/src/oidcop/oauth2/token.py
+++ b/src/oidcop/oauth2/token.py
@@ -53,6 +53,7 @@ class TokenEndpointHelper(object):
         session_id: str,
         client_id: str,
         based_on: Optional[SessionToken] = None,
+        scope: Optional[list] = None,
         token_args: Optional[dict] = None,
         token_type: Optional[str] = ""
     ) -> SessionToken:
@@ -80,6 +81,7 @@ class TokenEndpointHelper(object):
             token_handler=_mngr.token_handler[token_class],
             based_on=based_on,
             usage_rules=usage_rules,
+            scope=scope,
             token_type=token_type,
             **_args,
         )
@@ -135,7 +137,12 @@ class AccessTokenHelper(TokenEndpointHelper):
 
         _log_debug("All checks OK")
 
-        issue_refresh = kwargs.get("issue_refresh", False)
+        issue_refresh = False
+        if "issue_refresh" in kwargs:
+            issue_refresh = kwargs["issue_refresh"]
+        else:
+            if "offline_access" in grant.scope:
+                issue_refresh = True
 
         _response = {
             "token_type": "Bearer",
@@ -225,15 +232,29 @@ class RefreshTokenHelper(TokenEndpointHelper):
 
         token_value = req["refresh_token"]
         _session_info = _mngr.get_session_info_by_token(token_value, grant=True)
-
         _grant = _session_info["grant"]
+
+        token_type = "Bearer"
+
+        # Is DPOP supported
+        if "dpop_signing_alg_values_supported" in _context.provider_info:
+            _dpop_jkt = req.get("dpop_jkt")
+            if _dpop_jkt:
+                _grant.extra["dpop_jkt"] = _dpop_jkt
+                token_type = "DPoP"
+
         token = _grant.get_token(token_value)
+        scope = _grant.find_scope(token.based_on)
+        if "scope" in req:
+            scope = req["scope"]
         access_token = self._mint_token(
             token_class="access_token",
             grant=_grant,
             session_id=_session_info["session_id"],
             client_id=_session_info["client_id"],
             based_on=token,
+            scope=scope,
+            token_type=token_type,
         )
 
         _resp = {
@@ -246,13 +267,20 @@ class RefreshTokenHelper(TokenEndpointHelper):
             _resp["expires_in"] = access_token.expires_at - utc_time_sans_frac()
 
         _mints = token.usage_rules.get("supports_minting")
-        if "refresh_token" in _mints:
+        issue_refresh = False
+        if "issue_refresh" in kwargs:
+            issue_refresh = kwargs["issue_refresh"]
+        else:
+            if "offline_access" in scope:
+                issue_refresh = True
+        if "refresh_token" in _mints and issue_refresh:
             refresh_token = self._mint_token(
                 token_class="refresh_token",
                 grant=_grant,
                 session_id=_session_info["session_id"],
                 client_id=_session_info["client_id"],
                 based_on=token,
+                scope=scope,
             )
             refresh_token.usage_rules = token.usage_rules.copy()
             _resp["refresh_token"] = refresh_token.value
@@ -288,7 +316,8 @@ class RefreshTokenHelper(TokenEndpointHelper):
             logger.error("Access Code invalid")
             return self.error_cls(error="invalid_grant")
 
-        token = _session_info["grant"].get_token(request["refresh_token"])
+        grant = _session_info["grant"]
+        token = grant.get_token(request["refresh_token"])
 
         if not isinstance(token, RefreshToken):
             return self.error_cls(error="invalid_request", error_description="Wrong token type")
@@ -297,6 +326,15 @@ class RefreshTokenHelper(TokenEndpointHelper):
             return self.error_cls(
                 error="invalid_request", error_description="Refresh token inactive"
             )
+
+        if "scope" in request:
+            req_scopes = set(request["scope"])
+            scopes = set(grant.find_scope(token.based_on))
+            if scopes < req_scopes:
+                return self.error_cls(
+                    error="invalid_request",
+                    error_description="Invalid refresh scopes",
+                )
 
         return request
 

--- a/src/oidcop/oauth2/token.py
+++ b/src/oidcop/oauth2/token.py
@@ -137,13 +137,7 @@ class AccessTokenHelper(TokenEndpointHelper):
 
         _log_debug("All checks OK")
 
-        issue_refresh = False
-        if "issue_refresh" in kwargs:
-            issue_refresh = kwargs["issue_refresh"]
-        else:
-            if "offline_access" in grant.scope:
-                issue_refresh = True
-
+        issue_refresh = kwargs.get("issue_refresh", False)
         _response = {
             "token_type": "Bearer",
             "scope": grant.scope,
@@ -267,12 +261,7 @@ class RefreshTokenHelper(TokenEndpointHelper):
             _resp["expires_in"] = access_token.expires_at - utc_time_sans_frac()
 
         _mints = token.usage_rules.get("supports_minting")
-        issue_refresh = False
-        if "issue_refresh" in kwargs:
-            issue_refresh = kwargs["issue_refresh"]
-        else:
-            if "offline_access" in scope:
-                issue_refresh = True
+        issue_refresh = kwargs.get("issue_refresh", False)
         if "refresh_token" in _mints and issue_refresh:
             refresh_token = self._mint_token(
                 token_class="refresh_token",

--- a/tests/test_24_oauth2_token_endpoint.py
+++ b/tests/test_24_oauth2_token_endpoint.py
@@ -302,7 +302,7 @@ class TestEndpoint(object):
 
     def test_do_refresh_access_token(self):
         areq = AUTH_REQ.copy()
-        areq["scope"] = ["openid"]
+        areq["scope"] = ["openid", "offline_access"]
 
         session_id = self._create_session(areq)
         grant = self.endpoint_context.authz(session_id, areq)
@@ -361,7 +361,6 @@ class TestEndpoint(object):
         _token.usage_rules["supports_minting"] = [
             "access_token",
             "refresh_token",
-            "id_token",
         ]
 
         _req = self.token_endpoint.parse_request(_request.to_json())
@@ -421,6 +420,180 @@ class TestEndpoint(object):
         assert "refresh_token" in _3rd_resp["response_args"]
 
         assert first_refresh_token != second_refresh_token
+
+    def test_refresh_scopes(self):
+        areq = AUTH_REQ.copy()
+        areq["scope"] = ["openid", "offline_access", "profile"]
+
+        session_id = self._create_session(areq)
+        grant = self.endpoint_context.authz(session_id, areq)
+        code = self._mint_code(grant, areq["client_id"])
+
+        _token_request = TOKEN_REQ_DICT.copy()
+        _token_request["code"] = code.value
+        _req = self.token_endpoint.parse_request(_token_request)
+        _resp = self.token_endpoint.process_request(request=_req)
+
+        _request = REFRESH_TOKEN_REQ.copy()
+        _request["refresh_token"] = _resp["response_args"]["refresh_token"]
+        _request["scope"] = ["openid", "offline_access"]
+
+        _req = self.token_endpoint.parse_request(_request.to_json())
+        _resp = self.token_endpoint.process_request(request=_req)
+        assert set(_resp.keys()) == {"cookie", "response_args", "http_headers"}
+        assert set(_resp["response_args"].keys()) == {
+            "access_token",
+            "token_type",
+            "expires_in",
+            "refresh_token",
+            "scope",
+        }
+
+        _token_value = _resp["response_args"]["access_token"]
+        _session_info = self.session_manager.get_session_info_by_token(_token_value)
+        at = self.session_manager.find_token(
+            _session_info["session_id"], _token_value
+        )
+        rt = self.session_manager.find_token(
+            _session_info["session_id"], _resp["response_args"]["refresh_token"]
+        )
+
+        assert at.scope == rt.scope == _request["scope"]
+
+    def test_refresh_more_scopes(self):
+        areq = AUTH_REQ.copy()
+        areq["scope"] = ["openid", "offline_access"]
+
+        session_id = self._create_session(areq)
+        grant = self.endpoint_context.authz(session_id, areq)
+        code = self._mint_code(grant, areq["client_id"])
+
+        _token_request = TOKEN_REQ_DICT.copy()
+        _token_request["code"] = code.value
+        _req = self.token_endpoint.parse_request(_token_request)
+        _resp = self.token_endpoint.process_request(request=_req)
+
+        _request = REFRESH_TOKEN_REQ.copy()
+        _request["refresh_token"] = _resp["response_args"]["refresh_token"]
+        _request["scope"] = ["openid", "offline_access", "profile"]
+
+        _req = self.token_endpoint.parse_request(_request.to_json())
+        assert isinstance(_req, TokenErrorResponse)
+        _resp = self.token_endpoint.process_request(request=_req)
+
+        assert _resp.to_dict() == {
+            "error": "invalid_request",
+            "error_description": "Invalid refresh scopes"
+        }
+
+    def test_refresh_more_scopes_2(self):
+        areq = AUTH_REQ.copy()
+        areq["scope"] = ["openid", "offline_access", "profile"]
+
+        session_id = self._create_session(areq)
+        grant = self.endpoint_context.authz(session_id, areq)
+        code = self._mint_code(grant, areq["client_id"])
+
+        _token_request = TOKEN_REQ_DICT.copy()
+        _token_request["code"] = code.value
+        _req = self.token_endpoint.parse_request(_token_request)
+        _resp = self.token_endpoint.process_request(request=_req)
+
+        _request = REFRESH_TOKEN_REQ.copy()
+        _request["refresh_token"] = _resp["response_args"]["refresh_token"]
+        _request["scope"] = ["openid", "offline_access"]
+
+        _token_value = _resp["response_args"]["refresh_token"]
+
+        _req = self.token_endpoint.parse_request(_request.to_json())
+        _resp = self.token_endpoint.process_request(request=_req)
+
+        _token_value = _resp["response_args"]["refresh_token"]
+        _request["refresh_token"] = _token_value
+        # We should be able to request the original requests scopes
+        _request["scope"] = ["openid", "offline_access", "profile"]
+
+        _req = self.token_endpoint.parse_request(_request.to_json())
+        _resp = self.token_endpoint.process_request(request=_req)
+
+        assert set(_resp.keys()) == {"cookie", "response_args", "http_headers"}
+        assert set(_resp["response_args"].keys()) == {
+            "access_token",
+            "token_type",
+            "expires_in",
+            "refresh_token",
+            "scope",
+        }
+
+        _token_value = _resp["response_args"]["access_token"]
+        _session_info = self.session_manager.get_session_info_by_token(_token_value)
+        at = self.session_manager.find_token(
+            _session_info["session_id"], _token_value
+        )
+        rt = self.session_manager.find_token(
+            _session_info["session_id"], _resp["response_args"]["refresh_token"]
+        )
+
+        assert at.scope == rt.scope == _request["scope"]
+
+    def test_refresh_no_openid_scope(self):
+        areq = AUTH_REQ.copy()
+        areq["scope"] = ["openid", "offline_access"]
+
+        session_id = self._create_session(areq)
+        grant = self.endpoint_context.authz(session_id, areq)
+        code = self._mint_code(grant, areq["client_id"])
+
+        _token_request = TOKEN_REQ_DICT.copy()
+        _token_request["code"] = code.value
+        _req = self.token_endpoint.parse_request(_token_request)
+        _resp = self.token_endpoint.process_request(request=_req)
+
+        _request = REFRESH_TOKEN_REQ.copy()
+        _request["refresh_token"] = _resp["response_args"]["refresh_token"]
+        _request["scope"] = ["offline_access"]
+
+        _token_value = _resp["response_args"]["refresh_token"]
+
+        _req = self.token_endpoint.parse_request(_request.to_json())
+        _resp = self.token_endpoint.process_request(request=_req)
+
+        assert set(_resp.keys()) == {"cookie", "response_args", "http_headers"}
+        assert set(_resp["response_args"].keys()) == {
+            "access_token",
+            "token_type",
+            "expires_in",
+            "refresh_token",
+            "scope",
+        }
+
+    def test_refresh_no_offline_access_scope(self):
+        areq = AUTH_REQ.copy()
+        areq["scope"] = ["openid", "offline_access"]
+
+        session_id = self._create_session(areq)
+        grant = self.endpoint_context.authz(session_id, areq)
+        code = self._mint_code(grant, areq["client_id"])
+
+        _token_request = TOKEN_REQ_DICT.copy()
+        _token_request["code"] = code.value
+        _req = self.token_endpoint.parse_request(_token_request)
+        _resp = self.token_endpoint.process_request(request=_req)
+
+        _request = REFRESH_TOKEN_REQ.copy()
+        _request["refresh_token"] = _resp["response_args"]["refresh_token"]
+        _request["scope"] = ["openid"]
+
+        _req = self.token_endpoint.parse_request(_request.to_json())
+        _resp = self.token_endpoint.process_request(request=_req)
+
+        assert set(_resp.keys()) == {"cookie", "response_args", "http_headers"}
+        assert set(_resp["response_args"].keys()) == {
+            "access_token",
+            "token_type",
+            "expires_in",
+            "scope",
+        }
 
     def test_do_refresh_access_token_not_allowed(self):
         areq = AUTH_REQ.copy()

--- a/tests/test_24_oauth2_token_endpoint.py
+++ b/tests/test_24_oauth2_token_endpoint.py
@@ -47,7 +47,7 @@ CAPABILITIES = {
 AUTH_REQ = AuthorizationRequest(
     client_id="client_1",
     redirect_uri="https://example.com/cb",
-    scope=["openid"],
+    scope=["email"],
     state="STATE",
     response_type="code",
 )
@@ -302,7 +302,7 @@ class TestEndpoint(object):
 
     def test_do_refresh_access_token(self):
         areq = AUTH_REQ.copy()
-        areq["scope"] = ["openid", "offline_access"]
+        areq["scope"] = ["email"]
 
         session_id = self._create_session(areq)
         grant = self.endpoint_context.authz(session_id, areq)
@@ -324,7 +324,7 @@ class TestEndpoint(object):
         _token.usage_rules["supports_minting"] = ["access_token", "refresh_token"]
 
         _req = self.token_endpoint.parse_request(_request.to_json())
-        _resp = self.token_endpoint.process_request(request=_req)
+        _resp = self.token_endpoint.process_request(request=_req, issue_refresh=True)
         assert set(_resp.keys()) == {"cookie", "response_args", "http_headers"}
         assert set(_resp["response_args"].keys()) == {
             "access_token",
@@ -338,7 +338,7 @@ class TestEndpoint(object):
 
     def test_do_2nd_refresh_access_token(self):
         areq = AUTH_REQ.copy()
-        areq["scope"] = ["openid", "offline_access"]
+        areq["scope"] = ["email"]
 
         session_id = self._create_session(areq)
         grant = self.endpoint_context.authz(session_id, areq)
@@ -364,12 +364,12 @@ class TestEndpoint(object):
         ]
 
         _req = self.token_endpoint.parse_request(_request.to_json())
-        _resp = self.token_endpoint.process_request(request=_req)
+        _resp = self.token_endpoint.process_request(request=_req, issue_refresh=True)
 
         _2nd_request = REFRESH_TOKEN_REQ.copy()
         _2nd_request["refresh_token"] = _resp["response_args"]["refresh_token"]
         _2nd_req = self.token_endpoint.parse_request(_request.to_json())
-        _2nd_resp = self.token_endpoint.process_request(request=_req)
+        _2nd_resp = self.token_endpoint.process_request(request=_req, issue_refresh=True)
 
         assert set(_2nd_resp.keys()) == {"cookie", "response_args", "http_headers"}
         assert set(_2nd_resp["response_args"].keys()) == {
@@ -392,7 +392,7 @@ class TestEndpoint(object):
         }
 
         areq = AUTH_REQ.copy()
-        areq["scope"] = ["openid", "offline_access"]
+        areq["scope"] = ["email"]
 
         session_id = self._create_session(areq)
         grant = self.endpoint_context.authz(session_id, areq)
@@ -423,7 +423,7 @@ class TestEndpoint(object):
 
     def test_refresh_scopes(self):
         areq = AUTH_REQ.copy()
-        areq["scope"] = ["openid", "offline_access", "profile"]
+        areq["scope"] = ["email", "profile"]
 
         session_id = self._create_session(areq)
         grant = self.endpoint_context.authz(session_id, areq)
@@ -432,14 +432,14 @@ class TestEndpoint(object):
         _token_request = TOKEN_REQ_DICT.copy()
         _token_request["code"] = code.value
         _req = self.token_endpoint.parse_request(_token_request)
-        _resp = self.token_endpoint.process_request(request=_req)
+        _resp = self.token_endpoint.process_request(request=_req, issue_refresh=True)
 
         _request = REFRESH_TOKEN_REQ.copy()
         _request["refresh_token"] = _resp["response_args"]["refresh_token"]
-        _request["scope"] = ["openid", "offline_access"]
+        _request["scope"] = ["email"]
 
         _req = self.token_endpoint.parse_request(_request.to_json())
-        _resp = self.token_endpoint.process_request(request=_req)
+        _resp = self.token_endpoint.process_request(request=_req, issue_refresh=True)
         assert set(_resp.keys()) == {"cookie", "response_args", "http_headers"}
         assert set(_resp["response_args"].keys()) == {
             "access_token",
@@ -462,7 +462,7 @@ class TestEndpoint(object):
 
     def test_refresh_more_scopes(self):
         areq = AUTH_REQ.copy()
-        areq["scope"] = ["openid", "offline_access"]
+        areq["scope"] = ["email"]
 
         session_id = self._create_session(areq)
         grant = self.endpoint_context.authz(session_id, areq)
@@ -471,15 +471,15 @@ class TestEndpoint(object):
         _token_request = TOKEN_REQ_DICT.copy()
         _token_request["code"] = code.value
         _req = self.token_endpoint.parse_request(_token_request)
-        _resp = self.token_endpoint.process_request(request=_req)
+        _resp = self.token_endpoint.process_request(request=_req, issue_refresh=True)
 
         _request = REFRESH_TOKEN_REQ.copy()
         _request["refresh_token"] = _resp["response_args"]["refresh_token"]
-        _request["scope"] = ["openid", "offline_access", "profile"]
+        _request["scope"] = ["email", "profile"]
 
         _req = self.token_endpoint.parse_request(_request.to_json())
         assert isinstance(_req, TokenErrorResponse)
-        _resp = self.token_endpoint.process_request(request=_req)
+        _resp = self.token_endpoint.process_request(request=_req, issue_refresh=True)
 
         assert _resp.to_dict() == {
             "error": "invalid_request",
@@ -488,7 +488,7 @@ class TestEndpoint(object):
 
     def test_refresh_more_scopes_2(self):
         areq = AUTH_REQ.copy()
-        areq["scope"] = ["openid", "offline_access", "profile"]
+        areq["scope"] = ["email", "profile"]
 
         session_id = self._create_session(areq)
         grant = self.endpoint_context.authz(session_id, areq)
@@ -497,24 +497,24 @@ class TestEndpoint(object):
         _token_request = TOKEN_REQ_DICT.copy()
         _token_request["code"] = code.value
         _req = self.token_endpoint.parse_request(_token_request)
-        _resp = self.token_endpoint.process_request(request=_req)
+        _resp = self.token_endpoint.process_request(request=_req, issue_refresh=True)
 
         _request = REFRESH_TOKEN_REQ.copy()
         _request["refresh_token"] = _resp["response_args"]["refresh_token"]
-        _request["scope"] = ["openid", "offline_access"]
+        _request["scope"] = ["email"]
 
         _token_value = _resp["response_args"]["refresh_token"]
 
         _req = self.token_endpoint.parse_request(_request.to_json())
-        _resp = self.token_endpoint.process_request(request=_req)
+        _resp = self.token_endpoint.process_request(request=_req, issue_refresh=True)
 
         _token_value = _resp["response_args"]["refresh_token"]
         _request["refresh_token"] = _token_value
         # We should be able to request the original requests scopes
-        _request["scope"] = ["openid", "offline_access", "profile"]
+        _request["scope"] = ["email", "profile"]
 
         _req = self.token_endpoint.parse_request(_request.to_json())
-        _resp = self.token_endpoint.process_request(request=_req)
+        _resp = self.token_endpoint.process_request(request=_req, issue_refresh=True)
 
         assert set(_resp.keys()) == {"cookie", "response_args", "http_headers"}
         assert set(_resp["response_args"].keys()) == {
@@ -536,68 +536,9 @@ class TestEndpoint(object):
 
         assert at.scope == rt.scope == _request["scope"]
 
-    def test_refresh_no_openid_scope(self):
-        areq = AUTH_REQ.copy()
-        areq["scope"] = ["openid", "offline_access"]
-
-        session_id = self._create_session(areq)
-        grant = self.endpoint_context.authz(session_id, areq)
-        code = self._mint_code(grant, areq["client_id"])
-
-        _token_request = TOKEN_REQ_DICT.copy()
-        _token_request["code"] = code.value
-        _req = self.token_endpoint.parse_request(_token_request)
-        _resp = self.token_endpoint.process_request(request=_req)
-
-        _request = REFRESH_TOKEN_REQ.copy()
-        _request["refresh_token"] = _resp["response_args"]["refresh_token"]
-        _request["scope"] = ["offline_access"]
-
-        _token_value = _resp["response_args"]["refresh_token"]
-
-        _req = self.token_endpoint.parse_request(_request.to_json())
-        _resp = self.token_endpoint.process_request(request=_req)
-
-        assert set(_resp.keys()) == {"cookie", "response_args", "http_headers"}
-        assert set(_resp["response_args"].keys()) == {
-            "access_token",
-            "token_type",
-            "expires_in",
-            "refresh_token",
-            "scope",
-        }
-
-    def test_refresh_no_offline_access_scope(self):
-        areq = AUTH_REQ.copy()
-        areq["scope"] = ["openid", "offline_access"]
-
-        session_id = self._create_session(areq)
-        grant = self.endpoint_context.authz(session_id, areq)
-        code = self._mint_code(grant, areq["client_id"])
-
-        _token_request = TOKEN_REQ_DICT.copy()
-        _token_request["code"] = code.value
-        _req = self.token_endpoint.parse_request(_token_request)
-        _resp = self.token_endpoint.process_request(request=_req)
-
-        _request = REFRESH_TOKEN_REQ.copy()
-        _request["refresh_token"] = _resp["response_args"]["refresh_token"]
-        _request["scope"] = ["openid"]
-
-        _req = self.token_endpoint.parse_request(_request.to_json())
-        _resp = self.token_endpoint.process_request(request=_req)
-
-        assert set(_resp.keys()) == {"cookie", "response_args", "http_headers"}
-        assert set(_resp["response_args"].keys()) == {
-            "access_token",
-            "token_type",
-            "expires_in",
-            "scope",
-        }
-
     def test_do_refresh_access_token_not_allowed(self):
         areq = AUTH_REQ.copy()
-        areq["scope"] = ["openid", "offline_access"]
+        areq["scope"] = ["email"]
 
         session_id = self._create_session(areq)
         grant = self.endpoint_context.authz(session_id, areq)
@@ -621,7 +562,7 @@ class TestEndpoint(object):
 
     def test_do_refresh_access_token_revoked(self):
         areq = AUTH_REQ.copy()
-        areq["scope"] = ["openid"]
+        areq["scope"] = ["email"]
 
         session_id = self._create_session(areq)
         grant = self.endpoint_context.authz(session_id, areq)


### PR DESCRIPTION
Implement the scope parameter for refresh tokens as described in https://datatracker.ietf.org/doc/html/rfc6749#section-6

Also added the `offline_access` scope logic to oauth2 token endpoint.

If a client removes the `openid` scope from a refresh token request then a new ID token will not be issued.
If a client removes the `offline_access` scope from a refresh token request then a new refresh token will not be issued.