### PR TITLE
feat: default httpc_params configuration - added 4 second timeout

### DIFF
--- a/src/oidcop/configure.py
+++ b/src/oidcop/configure.py
@@ -65,7 +65,7 @@ OP_DEFAULT_CONFIG = {
             }
         },
     },
-    "httpc_params": {"verify": False},
+    "httpc_params": {"verify": False, "timeout": 4},
     "issuer": "https://{domain}:{port}",
     "template_dir": "templates",
     "token_handler_args": {
@@ -503,7 +503,7 @@ DEFAULT_EXTENDED_CONF = {
             },
         },
     },
-    "httpc_params": {"verify": False},
+    "httpc_params": {"verify": False, "timeout": 4},
     "issuer": "https://{domain}:{port}",
     "keys": {
         "private_path": "private/jwks.json",


### PR DESCRIPTION
using py38 I can't run these tests:

- tests/test_32_oidc_read_registration.py
- tests/test_23_oidc_registration_endpoint.py

The problem is due to a http connection that doesn't expire when tryng to get client jwks_uri

I believe that a default 4 seconds timeout would be the best choice, by default