### PR TITLE
WIP: Introduce add_claims_by_scope per client configuration

### DIFF
--- a/tests/test_01_claims.py
+++ b/tests/test_01_claims.py
@@ -114,6 +114,9 @@ class TestEndpoint(object):
             "client_salt": "salted",
             "token_endpoint_auth_method": "client_secret_post",
             "response_types": ["code", "token", "code id_token", "id_token"],
+            "add_claims": {
+                "always": {},
+            },
         }
         server.endpoint_context.keyjar.add_symmetric(
             "client_1", "hemligtochintekort", ["sig", "enc"]
@@ -173,17 +176,17 @@ class TestEndpoint(object):
         assert claims == {}
 
     def test_get_client_claims_id_token_1(self):
-        self.endpoint_context.cdb["client_1"]["id_token_claims"] = ["name", "email"]
+        self.endpoint_context.cdb["client_1"]["add_claims"]["always"]["id_token"] = ["name", "email"]
         claims = self.claims_interface._get_client_claims("client_1", "id_token")
         assert set(claims.keys()) == {"name", "email"}
 
     def test_get_client_claims_userinfo_1(self):
-        self.endpoint_context.cdb["client_1"]["userinfo_claims"] = ["email", "address"]
+        self.endpoint_context.cdb["client_1"]["add_claims"]["always"]["userinfo"] = ["email", "address"]
         claims = self.claims_interface._get_client_claims("client_1", "userinfo")
         assert set(claims.keys()) == {"address", "email"}
 
     def test_get_client_claims_introspection_1(self):
-        self.endpoint_context.cdb["client_1"]["introspection_claims"] = ["email"]
+        self.endpoint_context.cdb["client_1"]["add_claims"]["always"]["introspection"] = ["email"]
         claims = self.claims_interface._get_client_claims("client_1", "introspection")
         assert set(claims.keys()) == {"email"}
 
@@ -207,7 +210,7 @@ class TestEndpoint(object):
             "base_claims": {"email": None, "email_verified": None},
             "enable_claims_per_client": True,
         }
-        self.endpoint_context.cdb["client_1"]["id_token_claims"] = ["name", "email"]
+        self.endpoint_context.cdb["client_1"]["add_claims"]["always"]["id_token"] = ["name", "email"]
 
         claims = self.claims_interface.get_claims(session_id, [], "id_token")
         assert set(claims.keys()) == {"name", "email", "email_verified"}
@@ -219,7 +222,7 @@ class TestEndpoint(object):
             "enable_claims_per_client": True,
             "add_claims_by_scope": True,
         }
-        self.endpoint_context.cdb["client_1"]["id_token_claims"] = ["name", "email"]
+        self.endpoint_context.cdb["client_1"]["add_claims"]["always"]["id_token"] = ["name", "email"]
 
         claims = self.claims_interface.get_claims(session_id, ["openid", "address"], "id_token")
         assert set(claims.keys()) == {
@@ -238,7 +241,7 @@ class TestEndpoint(object):
             "enable_claims_per_client": True,
             "add_claims_by_scope": True,
         }
-        self.endpoint_context.cdb["client_1"]["userinfo_claims"] = ["name", "email"]
+        self.endpoint_context.cdb["client_1"]["add_claims"]["always"]["userinfo"] = ["name", "email"]
 
         claims = self.claims_interface.get_claims(session_id, ["openid", "address"], "userinfo")
         assert set(claims.keys()) == {
@@ -256,7 +259,7 @@ class TestEndpoint(object):
             "enable_claims_per_client": True,
             "add_claims_by_scope": True,
         }
-        self.endpoint_context.cdb["client_1"]["introspection_claims"] = [
+        self.endpoint_context.cdb["client_1"]["add_claims"]["always"]["introspection"] = [
             "name",
             "email",
         ]
@@ -280,7 +283,7 @@ class TestEndpoint(object):
             "enable_claims_per_client": True,
             "add_claims_by_scope": True,
         }
-        self.endpoint_context.cdb["client_1"]["access_token_claims"] = ["name", "email"]
+        self.endpoint_context.cdb["client_1"]["add_claims"]["always"]["access_token"] = ["name", "email"]
 
         session_id = self._create_session(AREQ)
         claims = self.claims_interface.get_claims(session_id, ["openid", "address"], "access_token")
@@ -320,7 +323,7 @@ class TestEndpoint(object):
         self.server.server_get("endpoint", "userinfo").kwargs = {
             "enable_claims_per_client": True,
         }
-        self.endpoint_context.cdb["client_1"]["userinfo_claims"] = ["name", "email"]
+        self.endpoint_context.cdb["client_1"]["add_claims"]["always"]["userinfo"] = ["name", "email"]
 
         self.server.server_get("endpoint", "introspection").kwargs = {"add_claims_by_scope": True}
 
@@ -349,7 +352,7 @@ class TestEndpoint(object):
         self.server.server_get("endpoint", "userinfo").kwargs = {
             "enable_claims_per_client": True,
         }
-        self.endpoint_context.cdb["client_1"]["userinfo_claims"] = ["name", "email"]
+        self.endpoint_context.cdb["client_1"]["add_claims"]["always"]["userinfo"] = ["name", "email"]
 
         self.server.server_get("endpoint", "introspection").kwargs = {"add_claims_by_scope": True}
 

--- a/tests/test_05_jwt_token.py
+++ b/tests/test_05_jwt_token.py
@@ -186,6 +186,10 @@ class TestEndpoint(object):
             "client_salt": "salted",
             "token_endpoint_auth_method": "client_secret_post",
             "response_types": ["code", "token", "code id_token", "id_token"],
+            "add_claims": {
+                "always": {},
+                "by_scope": {},
+            },
         }
         self.session_manager = self.endpoint_context.session_manager
         self.user_id = "diana"
@@ -247,7 +251,7 @@ class TestEndpoint(object):
     @pytest.mark.parametrize("enable_claims_per_client", [True, False])
     def test_enable_claims_per_client(self, enable_claims_per_client):
         # Set up configuration
-        self.endpoint_context.cdb["client_1"]["access_token_claims"] = {"address": None}
+        self.endpoint_context.cdb["client_1"]["add_claims"]["always"]["access_token"] = {"address": None}
         self.endpoint_context.session_manager.token_handler.handler["access_token"].kwargs[
             "enable_claims_per_client"
         ] = enable_claims_per_client

--- a/tests/test_07_userinfo.py
+++ b/tests/test_07_userinfo.py
@@ -255,7 +255,12 @@ class TestCollectUserInfo:
         server = Server(OPConfiguration(conf=conf, base_path=BASEDIR), cwd=BASEDIR)
         self.endpoint_context = server.endpoint_context
         # Just has to be there
-        self.endpoint_context.cdb["client1"] = {}
+        self.endpoint_context.cdb["client1"] = {
+            "add_claims": {
+                "always": {},
+                "by_scope": {},
+            },
+        }
         self.session_manager = self.endpoint_context.session_manager
         self.claims_interface = ClaimsInterface(server.server_get)
         self.user_id = "diana"
@@ -371,7 +376,7 @@ class TestCollectUserInfo:
         _userinfo_endpoint.kwargs["enable_claims_per_client"] = True
         del _userinfo_endpoint.kwargs["base_claims"]
 
-        self.endpoint_context.cdb[_req["client_id"]]["userinfo_claims"] = {"phone_number": None}
+        self.endpoint_context.cdb[_req["client_id"]]["add_claims"]["always"]["userinfo"] = {"phone_number": None}
 
         _userinfo_restriction = self.claims_interface.get_claims(
             session_id=session_id, scopes=_req["scope"], claims_release_point="userinfo"

--- a/tests/test_31_oauth2_introspection.py
+++ b/tests/test_31_oauth2_introspection.py
@@ -192,7 +192,12 @@ class TestEndpoint:
             "client_salt": "salted",
             "token_endpoint_auth_method": "client_secret_post",
             "response_types": ["code", "token", "code id_token", "id_token"],
-            "introspection_claims": {"nickname": None, "eduperson_scoped_affiliation": None,},
+            "add_claims": {
+                "always": {
+                    "introspection": ["nickname", "eduperson_scoped_affiliation"],
+                },
+                "by_scope": {},
+            },
         }
         endpoint_context.keyjar.import_jwks_as_json(
             endpoint_context.keyjar.export_jwks_as_json(private=True), endpoint_context.issuer,


### PR DESCRIPTION
This MR enables per client configuration for add_claims_by_scope parameter.
If configuration for specific client exists, it overrides the global configuration.

For example consider the following list of clients and that the default oidc-op configuration sets `add_claims_by_scope = True`:

```yaml
oidc_clients:
  client1:
    # client secret is "password"
    client_secret: "Namnam"
    redirect_uris:
      - ['https://openidconnect.net/callback', '']
    response_types:
      - code
    add_claims_by_scope: False
    
  client2:
    client_secret: "spraket"
    redirect_uris:
      - ['https://app1.example.net/foo', '']
      - ['https://app2.example.net/bar', '']
    response_types:
      - code
```
Also consider the two clients form the following authorization request where `CLIENT_ID` is "client1" and "client2" respectively:

```
AREQS = AuthorizationRequest(
    response_type="code",
    client_id=CLIENT_ID,
    redirect_uri="http://example.com/authz",
    scope=["openid", "address", "email"],
    state="state000",
    nonce="nonce",
)

```
As long as for "client1"  `add_claims_by_scope = False`, the returned claims will be the union of the base claims and the explicit claims requested for this user given `enable_claims_per_client = True`.

On the other hand, for "client2" the returned claims will be the same as for "client1" plus the the claims that correspond to the requested scopes after `oidcop.scopes.convert_scopes2claims()` is applied.