### PR TITLE
Don't create a new client session every time

### DIFF
--- a/src/oidcop/session/manager.py
+++ b/src/oidcop/session/manager.py
@@ -12,6 +12,7 @@ from oidcop.authn_event import AuthnEvent
 from oidcop.exception import ConfigurationError
 from oidcop.token import handler
 from oidcop.util import Crypt
+from oidcop.session.database import NoSuchClientSession
 from .database import Database
 from .grant import Grant
 from .grant import SessionToken
@@ -226,9 +227,11 @@ class SessionManager(Database):
         if not client_id:
             client_id = auth_req["client_id"]
 
-        client_info = ClientSessionInfo(client_id=client_id)
-
-        self.set([user_id, client_id], client_info)
+        try:
+            self.get([user_id, client_id])
+        except (NoSuchClientSession, ValueError):
+            client_info = ClientSessionInfo(client_id=client_id)
+            self.set([user_id, client_id], client_info)
 
         return self.create_grant(
             auth_req=auth_req,

--- a/tests/test_34_oidc_sso.py
+++ b/tests/test_34_oidc_sso.py
@@ -255,4 +255,4 @@ class TestUserAuthn(object):
 
         assert len(csi1.subordinate) == 2
         assert len(csi2.subordinate) == 1
-        assert len(csi3.subordinate) == 1
+        assert len(csi3.subordinate) == 2


### PR DESCRIPTION
A new client session was created every time create_session was called, this resulted in losing the client subordinates.

Have you stumbled onto this or am I misusing `create_session`?