### PR TITLE
Fix refresh tokens

### DIFF
--- a/src/oidcop/oauth2/token.py
+++ b/src/oidcop/oauth2/token.py
@@ -253,7 +253,7 @@ class RefreshTokenHelper(TokenEndpointHelper):
         _resp = {
             "access_token": access_token.value,
             "token_type": access_token.token_type,
-            "scope": _grant.scope,
+            "scope": scope,
         }
 
         if access_token.expires_at:
@@ -318,7 +318,7 @@ class RefreshTokenHelper(TokenEndpointHelper):
         if "scope" in request:
             req_scopes = set(request["scope"])
             scopes = set(grant.find_scope(token.based_on))
-            if scopes < req_scopes:
+            if not req_scopes.issubset(scopes):
                 return self.error_cls(
                     error="invalid_request",
                     error_description="Invalid refresh scopes",

--- a/src/oidcop/oidc/token.py
+++ b/src/oidcop/oidc/token.py
@@ -246,7 +246,7 @@ class RefreshTokenHelper(TokenEndpointHelper):
         if "id_token" in _mints and "openid" in scope:
             try:
                 _idtoken = self._mint_token(
-                    token_class="refresh_token",
+                    token_class="id_token",
                     grant=_grant,
                     session_id=_session_info["session_id"],
                     client_id=_session_info["client_id"],

--- a/src/oidcop/oidc/token.py
+++ b/src/oidcop/oidc/token.py
@@ -218,7 +218,7 @@ class RefreshTokenHelper(TokenEndpointHelper):
         _resp = {
             "access_token": access_token.value,
             "token_type": token_type,
-            "scope": _grant.scope,
+            "scope": scope,
         }
 
         if access_token.expires_at:
@@ -307,7 +307,7 @@ class RefreshTokenHelper(TokenEndpointHelper):
         if "scope" in request:
             req_scopes = set(request["scope"])
             scopes = set(grant.find_scope(token.based_on))
-            if scopes < req_scopes:
+            if not req_scopes.issubset(scopes):
                 return self.error_cls(
                     error="invalid_request",
                     error_description="Invalid refresh scopes",

--- a/tests/test_05_id_token.py
+++ b/tests/test_05_id_token.py
@@ -235,6 +235,11 @@ class TestEndpoint(object):
             "nonce",
             "iat",
             "exp",
+            "email",
+            "email_verified",
+            "jti",
+            "scope",
+            "client_id",
             "iss",
         }
 
@@ -252,6 +257,11 @@ class TestEndpoint(object):
             "auth_time",
             "aud",
             "exp",
+            "email",
+            "email_verified",
+            "jti",
+            "scope",
+            "client_id",
             "c_hash",
             "iss",
             "iat",
@@ -277,6 +287,11 @@ class TestEndpoint(object):
             "auth_time",
             "aud",
             "exp",
+            "email",
+            "email_verified",
+            "jti",
+            "scope",
+            "client_id",
             "iss",
             "iat",
             "nonce",
@@ -300,6 +315,11 @@ class TestEndpoint(object):
             "auth_time",
             "aud",
             "exp",
+            "email",
+            "email_verified",
+            "jti",
+            "scope",
+            "client_id",
             "iss",
             "iat",
             "nonce",
@@ -308,9 +328,10 @@ class TestEndpoint(object):
         }
 
     def test_id_token_payload_with_userinfo(self):
-        session_id = self._create_session(AREQ)
+        req = dict(AREQ)
+        req["claims"] = {"id_token": {"given_name": None}}
+        session_id = self._create_session(req)
         grant = self.session_manager[session_id]
-        grant.claims = {"id_token": {"given_name": None}}
 
         id_token = self._mint_id_token(grant, session_id)
 
@@ -320,6 +341,11 @@ class TestEndpoint(object):
             "nonce",
             "iat",
             "iss",
+            "email",
+            "email_verified",
+            "jti",
+            "scope",
+            "client_id",
             "given_name",
             "aud",
             "exp",
@@ -328,9 +354,10 @@ class TestEndpoint(object):
         }
 
     def test_id_token_payload_many_0(self):
-        session_id = self._create_session(AREQ)
+        req = dict(AREQ)
+        req["claims"] = {"id_token": {"given_name": None}}
+        session_id = self._create_session(req)
         grant = self.session_manager[session_id]
-        grant.claims = {"id_token": {"given_name": None}}
         code = self._mint_code(grant, session_id)
         access_token = self._mint_access_token(grant, session_id, code)
 
@@ -344,6 +371,11 @@ class TestEndpoint(object):
             "nonce",
             "c_hash",
             "at_hash",
+            "email",
+            "email_verified",
+            "jti",
+            "scope",
+            "client_id",
             "sub",
             "auth_time",
             "given_name",
@@ -391,9 +423,10 @@ class TestEndpoint(object):
         }
 
     def test_available_claims(self):
-        session_id = self._create_session(AREQ)
+        req = dict(AREQ)
+        req["claims"] = {"id_token": {"nickname": {"essential": True}}}
+        session_id = self._create_session(req)
         grant = self.session_manager[session_id]
-        grant.claims = {"id_token": {"nickname": {"essential": True}}}
 
         id_token = self._mint_id_token(grant, session_id)
 
@@ -497,11 +530,7 @@ class TestEndpoint(object):
         grant = self.session_manager[session_id]
 
         self.session_manager.token_handler["id_token"].kwargs["add_claims_by_scope"] = True
-
-        _claims = self.endpoint_context.claims_interface.get_claims(
-            session_id=session_id, scopes=AREQS["scope"], claims_release_point="id_token"
-        )
-        grant.claims = {"id_token": _claims}
+        grant.scope = AREQS["scope"]
 
         id_token = self._mint_id_token(grant, session_id)
 
@@ -519,11 +548,7 @@ class TestEndpoint(object):
         grant = self.session_manager[session_id]
 
         self.session_manager.token_handler["id_token"].kwargs["add_claims_by_scope"] = True
-
-        _claims = self.endpoint_context.claims_interface.get_claims(
-            session_id=session_id, scopes=AREQRC["scope"], claims_release_point="id_token"
-        )
-        grant.claims = {"id_token": _claims}
+        grant.scope = AREQRC["scope"]
 
         id_token = self._mint_id_token(grant, session_id)
 
@@ -546,11 +571,7 @@ class TestEndpoint(object):
         grant = self.session_manager[session_id]
 
         self.session_manager.token_handler["id_token"].kwargs["add_claims_by_scope"] = True
-
-        _claims = self.endpoint_context.claims_interface.get_claims(
-            session_id=session_id, scopes=_req["scope"], claims_release_point="id_token"
-        )
-        grant.claims = {"id_token": _claims}
+        grant.scope = _req["scope"]
 
         id_token = self._mint_id_token(grant, session_id)
 

--- a/tests/test_24_oauth2_token_endpoint.py
+++ b/tests/test_24_oauth2_token_endpoint.py
@@ -458,7 +458,7 @@ class TestEndpoint(object):
             _session_info["session_id"], _resp["response_args"]["refresh_token"]
         )
 
-        assert at.scope == rt.scope == _request["scope"]
+        assert at.scope == rt.scope == _request["scope"] == _resp["response_args"]["scope"]
 
     def test_refresh_more_scopes(self):
         areq = AUTH_REQ.copy()
@@ -475,7 +475,7 @@ class TestEndpoint(object):
 
         _request = REFRESH_TOKEN_REQ.copy()
         _request["refresh_token"] = _resp["response_args"]["refresh_token"]
-        _request["scope"] = ["email", "profile"]
+        _request["scope"] = ["ema"]
 
         _req = self.token_endpoint.parse_request(_request.to_json())
         assert isinstance(_req, TokenErrorResponse)
@@ -534,7 +534,7 @@ class TestEndpoint(object):
             _session_info["session_id"], _resp["response_args"]["refresh_token"]
         )
 
-        assert at.scope == rt.scope == _request["scope"]
+        assert at.scope == rt.scope == _request["scope"] == _resp["response_args"]["scope"]
 
     def test_do_refresh_access_token_not_allowed(self):
         areq = AUTH_REQ.copy()

--- a/tests/test_35_oidc_token_endpoint.py
+++ b/tests/test_35_oidc_token_endpoint.py
@@ -2,14 +2,15 @@ import base64
 import json
 import os
 
+import pytest
 from cryptojwt import JWT
 from cryptojwt.key_jar import build_keyjar
 from oidcmsg.oidc import AccessTokenRequest
 from oidcmsg.oidc import AuthorizationRequest
+from oidcmsg.oidc import AuthorizationResponse
 from oidcmsg.oidc import RefreshAccessTokenRequest
 from oidcmsg.oidc import TokenErrorResponse
 from oidcmsg.time_util import utc_time_sans_frac
-import pytest
 
 from oidcop import JWT_BEARER
 from oidcop.authn_event import create_authn_event
@@ -372,6 +373,10 @@ class TestEndpoint(object):
             "id_token",
             "scope",
         }
+        AuthorizationResponse().from_jwt(
+            _resp["response_args"]["id_token"], _cntx.keyjar, sender=""
+        )
+
         msg = self.token_endpoint.do_response(request=_req, **_resp)
         assert isinstance(msg, dict)
 
@@ -420,6 +425,10 @@ class TestEndpoint(object):
             "id_token",
             "scope",
         }
+        AuthorizationResponse().from_jwt(
+            _2nd_resp["response_args"]["id_token"], _cntx.keyjar, sender=""
+        )
+
         msg = self.token_endpoint.do_response(request=_req, **_resp)
         assert isinstance(msg, dict)
 
@@ -460,6 +469,11 @@ class TestEndpoint(object):
             "id_token",
             "scope",
         }
+        AuthorizationResponse().from_jwt(
+            _resp["response_args"]["id_token"],
+            self.endpoint_context.keyjar,
+            sender="",
+        )
 
         _token_value = _resp["response_args"]["access_token"]
         _session_info = self.session_manager.get_session_info_by_token(_token_value)
@@ -560,6 +574,11 @@ class TestEndpoint(object):
             "id_token",
             "scope",
         }
+        AuthorizationResponse().from_jwt(
+            _resp["response_args"]["id_token"],
+            self.endpoint_context.keyjar,
+            sender="",
+        )
 
         _token_value = _resp["response_args"]["access_token"]
         _session_info = self.session_manager.get_session_info_by_token(_token_value)
@@ -647,6 +666,11 @@ class TestEndpoint(object):
             "id_token",
             "scope",
         }
+        AuthorizationResponse().from_jwt(
+            _resp["response_args"]["id_token"],
+            self.endpoint_context.keyjar,
+            sender="",
+        )
 
     def test_new_refresh_token(self, conf):
         self.endpoint_context.cdb["client_1"] = {

--- a/tests/test_35_oidc_token_endpoint.py
+++ b/tests/test_35_oidc_token_endpoint.py
@@ -485,7 +485,7 @@ class TestEndpoint(object):
             _session_info["session_id"], _resp["response_args"]["refresh_token"]
         )
 
-        assert at.scope == rt.scope == _request["scope"]
+        assert at.scope == rt.scope == _request["scope"] == _resp["response_args"]["scope"]
 
     def test_refresh_more_scopes(self):
         areq = AUTH_REQ.copy()
@@ -590,7 +590,7 @@ class TestEndpoint(object):
             _session_info["session_id"], _resp["response_args"]["refresh_token"]
         )
 
-        assert at.scope == rt.scope == _request["scope"]
+        assert at.scope == rt.scope == _request["scope"] == _resp["response_args"]["scope"]
 
     def test_refresh_less_scopes(self):
         areq = AUTH_REQ.copy()
@@ -635,6 +635,7 @@ class TestEndpoint(object):
         )
 
         assert "email" not in idtoken
+        assert  _resp["response_args"]["scope"] == ["openid", "offline_access"]
 
     def test_refresh_no_openid_scope(self):
         areq = AUTH_REQ.copy()
@@ -673,6 +674,7 @@ class TestEndpoint(object):
             "refresh_token",
             "scope",
         }
+        assert _resp["response_args"]["scope"] == ["offline_access"]
 
     def test_refresh_no_offline_access_scope(self):
         areq = AUTH_REQ.copy()
@@ -716,6 +718,7 @@ class TestEndpoint(object):
             self.endpoint_context.keyjar,
             sender="",
         )
+        assert _resp["response_args"]["scope"] == ["openid"]
 
     def test_new_refresh_token(self, conf):
         self.endpoint_context.cdb["client_1"] = {


### PR DESCRIPTION
Fixes various issues with refresh:
- The id tokens issued after a refresh were not JWTs.
- Also fixed the way claims were added to the ID tokens, the claims that were passed from the grant were ignored.
- The scopes returned were not correct (we returned the scopes of the original authorization request, not of this request).
- We didn't always return an error when invalid scopes were requested