### PR TITLE
Fix JWT access token lifetime

### DIFF
--- a/src/oidcop/session/grant.py
+++ b/src/oidcop/session/grant.py
@@ -316,7 +316,9 @@ class Grant(Item):
                 scope=scope,
                 extra_payload=handler_args,
             )
-            item.value = token_handler(session_id=session_id, **token_payload)
+            item.value = token_handler(
+                session_id=session_id, usage_rules=usage_rules, **token_payload
+            )
 
         else:
             raise ValueError("Can not mint that kind of token")

--- a/src/oidcop/token/id_token.py
+++ b/src/oidcop/token/id_token.py
@@ -267,6 +267,7 @@ class IDToken(Token):
         encrypt=False,
         code=None,
         access_token=None,
+        usage_rules: Optional[dict] = None,
         **kwargs,
     ) -> str:
         _context = self.server_get("endpoint_context")

--- a/src/oidcop/token/jwt_token.py
+++ b/src/oidcop/token/jwt_token.py
@@ -48,8 +48,13 @@ class JWTToken(Token):
         # inherit me and do your things here
         return payload
 
-    def __call__(self, session_id: Optional[str] = "", token_class: Optional[str] = "",
-                 **payload) -> str:
+    def __call__(
+        self,
+        session_id: Optional[str] = "",
+        token_class: Optional[str] = "",
+        usage_rules: Optional[dict] = None,
+        **payload
+    ) -> str:
 
         """
         Return a token.
@@ -70,8 +75,15 @@ class JWTToken(Token):
 
         # payload.update(kwargs)
         _context = self.server_get("endpoint_context")
+        if usage_rules and "expires_in" in usage_rules:
+            lifetime = usage_rules.get("expires_in")
+        else:
+            lifetime = self.lifetime
         signer = JWT(
-            key_jar=_context.keyjar, iss=self.issuer, lifetime=self.lifetime, sign_alg=self.alg,
+            key_jar=_context.keyjar,
+            iss=self.issuer,
+            lifetime=lifetime,
+            sign_alg=self.alg,
         )
 
         return signer.pack(payload)


### PR DESCRIPTION
The `expires_in` defined in usage rules was not reflected to the access token when it was a JWT