### PR TITLE
Handle exception raised from expired JWT access token

### DIFF
--- a/src/oidcop/client_authn.py
+++ b/src/oidcop/client_authn.py
@@ -22,6 +22,7 @@ from oidcop.endpoint_context import EndpointContext
 from oidcop.exception import InvalidClient
 from oidcop.exception import MultipleUsage
 from oidcop.exception import NotForMe
+from oidcop.exception import ToOld
 from oidcop.exception import UnknownClient
 from oidcop.util import importer
 
@@ -409,6 +410,8 @@ def verify_client(
         try:
             # get_client_id_from_token is a callback... Do not abuse for code readability.
             auth_info["client_id"] = get_client_id_from_token(endpoint_context, _token, request)
+        except ToOld:
+            raise ValueError("Expired token")
         except KeyError:
             raise ValueError("Unknown token")
 


### PR DESCRIPTION
Using an expired JWT access token in the userinfo endpoint would raise an unhandled `ToOld` exception. This PR fixes that