### PR TITLE
Missing userinfo in Configuration now raises an exception 

### DIFF
--- a/src/oidcop/session/claims.py
+++ b/src/oidcop/session/claims.py
@@ -128,13 +128,13 @@ class ClaimsInterface:
         :param claims_restriction: Specifies the upper limit of which claims can be returned
         :return:
         """
+        # Get all possible claims
+        meth = self.server_get("endpoint_context").userinfo
+        if not meth:
+            raise ImproperlyConfigured(
+                "userinfo MUST be defined in the configuration"
+            )
         if claims_restriction:
-            # Get all possible claims
-            meth = self.server_get("endpoint_context").userinfo
-            if not meth:
-                raise ImproperlyConfigured(
-                    "userinfo MUST be defined in the configuration"
-                )
             user_info = meth(user_id, client_id=None)
             # Filter out the claims that can be returned
             return {

--- a/src/oidcop/session/claims.py
+++ b/src/oidcop/session/claims.py
@@ -128,13 +128,13 @@ class ClaimsInterface:
         :param claims_restriction: Specifies the upper limit of which claims can be returned
         :return:
         """
-        # Get all possible claims
         meth = self.server_get("endpoint_context").userinfo
         if not meth:
             raise ImproperlyConfigured(
                 "userinfo MUST be defined in the configuration"
             )
         if claims_restriction:
+            # Get all possible claims
             user_info = meth(user_id, client_id=None)
             # Filter out the claims that can be returned
             return {

--- a/src/oidcop/session/claims.py
+++ b/src/oidcop/session/claims.py
@@ -5,6 +5,7 @@ from typing import Union
 from oidcmsg.oidc import OpenIDSchema
 
 from oidcop.exception import ServiceError
+from oidcop.exception import ImproperlyConfigured
 from oidcop.scopes import convert_scopes2claims
 
 logger = logging.getLogger(__name__)
@@ -129,7 +130,12 @@ class ClaimsInterface:
         """
         if claims_restriction:
             # Get all possible claims
-            user_info = self.server_get("endpoint_context").userinfo(user_id, client_id=None)
+            meth = self.server_get("endpoint_context").userinfo
+            if not meth:
+                raise ImproperlyConfigured(
+                    "userinfo MUST be defined in the configuration"
+                )
+            user_info = meth(user_id, client_id=None)
             # Filter out the claims that can be returned
             return {
                 k: user_info.get(k)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+import os
+
+BASEDIR = os.path.abspath(os.path.dirname(__file__))
+
+
+def full_path(local_file):
+    return os.path.join(BASEDIR, local_file)

--- a/tests/test_01_grant.py
+++ b/tests/test_01_grant.py
@@ -2,6 +2,7 @@ import pytest
 from cryptojwt.key_jar import build_keyjar
 from oidcmsg.oidc import AuthorizationRequest
 
+from . import full_path
 from oidcop.authn_event import create_authn_event
 from oidcop.server import Server
 from oidcop.session.grant import TOKEN_MAP
@@ -19,6 +20,7 @@ KEYDEFS = [
 ]
 
 KEYJAR = build_keyjar(KEYDEFS)
+
 
 conf = {
     "issuer": "https://example.com/",
@@ -40,6 +42,10 @@ conf = {
         }
     },
     "claims_interface": {"class": "oidcop.session.claims.ClaimsInterface", "kwargs": {}},
+    "userinfo": {
+        "class": "oidcop.user_info.UserInfo",
+        "kwargs": {"db_file": full_path("users.json")},
+    },
 }
 
 USER_ID = "diana"

--- a/tests/test_06_session_manager.py
+++ b/tests/test_06_session_manager.py
@@ -2,6 +2,7 @@ from oidcmsg.oidc import AuthorizationRequest
 from oidcmsg.time_util import time_sans_frac
 import pytest
 
+from . import full_path
 from oidcop.authn_event import AuthnEvent
 from oidcop.authn_event import create_authn_event
 from oidcop.authz import AuthzHandling
@@ -74,6 +75,10 @@ class TestSessionManager:
             },
             "template_dir": "template",
             "claims_interface": {"class": "oidcop.session.claims.ClaimsInterface", "kwargs": {}},
+            "userinfo": {
+                "class": "oidcop.user_info.UserInfo",
+                "kwargs": {"db_file": full_path("users.json")},
+            },
         }
         server = Server(conf)
         self.server = server

--- a/tests/test_08_session_life.py
+++ b/tests/test_08_session_life.py
@@ -8,6 +8,7 @@ from oidcmsg.oidc import AuthorizationRequest
 from oidcmsg.oidc import RefreshAccessTokenRequest
 from oidcmsg.time_util import time_sans_frac
 
+from . import full_path
 from oidcop import user_info
 from oidcop.authn_event import create_authn_event
 from oidcop.client_authn import verify_client
@@ -50,6 +51,10 @@ class TestSession:
                 "token_endpoint": {"path": "{}/token", "class": Token, "kwargs": {}},
             },
             "template_dir": "template",
+            "userinfo": {
+                "class": "oidcop.user_info.UserInfo",
+                "kwargs": {"db_file": full_path("users.json")},
+            },
         }
         server = Server(OPConfiguration(conf=conf, base_path=BASEDIR), cwd=BASEDIR)
 

--- a/tests/test_26_oidc_userinfo_endpoint.py
+++ b/tests/test_26_oidc_userinfo_endpoint.py
@@ -11,6 +11,7 @@ from oidcop import user_info
 from oidcop.authn_event import create_authn_event
 from oidcop.configure import OPConfiguration
 from oidcop.cookie_handler import CookieHandler
+from oidcop.exception import ImproperlyConfigured
 from oidcop.oidc import userinfo
 from oidcop.oidc.authorization import Authorization
 from oidcop.oidc.provider_config import ProviderConfiguration
@@ -439,3 +440,14 @@ class TestEndpoint(object):
         res = self.endpoint.do_response(request=_req, **args)
         _response = json.loads(res["response"])
         assert _response["acr"] == _acr
+
+    def test_process_request_absent_userinfo_conf(self):
+        # consider to have a configuration without userinfo defined in
+        ec = self.endpoint.server_get('endpoint_context')
+        ec.userinfo = None
+
+        session_id = self._create_session(AUTH_REQ)
+        grant = self.session_manager[session_id]
+
+        with pytest.raises(ImproperlyConfigured):
+            code = self._mint_code(grant, session_id)

--- a/tests/test_33_oauth2_pkce.py
+++ b/tests/test_33_oauth2_pkce.py
@@ -4,6 +4,7 @@ import os
 import secrets
 import string
 
+from . import full_path
 from oidcop.configure import ASConfiguration
 import pytest
 import yaml
@@ -160,6 +161,10 @@ def conf():
                     "session_management": "oidc_op_sman",
                 },
             },
+        },
+        "userinfo": {
+            "class": "oidcop.user_info.UserInfo",
+            "kwargs": {"db_file": full_path("users.json")},
         },
     }
 

--- a/tests/test_34_oidc_sso.py
+++ b/tests/test_34_oidc_sso.py
@@ -2,6 +2,7 @@ import io
 import json
 import os
 
+from . import full_path
 from oidcop.configure import OPConfiguration
 import pytest
 import yaml
@@ -89,11 +90,11 @@ oidc_clients:
   client_1:
     client_secret: hemligtkodord,
     client_id: client_1,
-    "redirect_uris": 
+    "redirect_uris":
         - ['https://example.com/cb', '']
     "client_salt": "salted"
     'token_endpoint_auth_method': 'client_secret_post'
-    'response_types': 
+    'response_types':
         - 'code'
         - 'token'
         - 'code id_token'
@@ -158,6 +159,10 @@ class TestUserAuthn(object):
                 },
             },
             "template_dir": "template",
+            "userinfo": {
+                "class": "oidcop.user_info.UserInfo",
+                "kwargs": {"db_file": full_path("users.json")},
+            },
         }
         server = Server(OPConfiguration(conf=conf, base_path=BASEDIR), cwd=BASEDIR)
 


### PR DESCRIPTION
Working on SATOSA integration I found that when userinfo is missign in oidcop configuration we get

TypeError: 'NoneType' object is not callable

With this PR we get instead a more eloquent exception (message)