### PR TITLE
Refactor scopes configuration

### DIFF
--- a/docs/source/contents/conf.rst
+++ b/docs/source/contents/conf.rst
@@ -53,6 +53,28 @@ sub_funcs
 
 Optional. Functions involved in *sub*ject value creation.
 
+
+
+scopes_mapping
+##############
+
+A dict defining the scopes that are allowed to be used per client and the claims
+they map to (defaults to the scopes mapping described in the spec). If we want
+to define a scope that doesn't map to claims (e.g. offline_access) then we
+simply map it to an empty list. E.g.::
+  {
+    "scope_a": ["claim1", "claim2"],
+    "scope_b": []
+  }
+*Note*: For OIDC the `openid` scope must be present in this mapping.
+
+
+allowed_scopes
+##############
+
+A list with the scopes that are allowed to be used (defaults to the keys in scopes_mapping).
+
+
 ------
 add_on
 ------
@@ -67,21 +89,6 @@ An example::
             "code_challenge_method": "S256 S384 S512"
           }
         },
-        "claims": {
-          "function": "oidcop.oidc.add_on.custom_scopes.add_custom_scopes",
-          "kwargs": {
-            "research_and_scholarship": [
-              "name",
-              "given_name",
-              "family_name",
-              "email",
-              "email_verified",
-              "sub",
-              "iss",
-              "eduperson_scoped_affiliation"
-            ]
-          }
-        }
       }
 
 The provided add-ons can be seen in the following sections.
@@ -176,6 +183,8 @@ An example::
       backchannel_logout_supported: True
       backchannel_logout_session_supported: True
       check_session_iframe: https://127.0.0.1:5000/check_session_iframe
+      scopes_supported: ["openid", "profile", "random"]
+      claims_supported: ["sub", "given_name", "birthdate"]
 
 ---------
 client_db
@@ -720,3 +729,23 @@ grant_types_supported
 ---------------------
 
 Configure the allowed grant types on the token endpoint.
+
+--------------
+scopes_mapping
+--------------
+
+A dict defining the scopes that are allowed to be used per client and the claims
+they map to (defaults to the scopes mapping described in the spec). If we want
+to define a scope that doesn't map to claims (e.g. offline_access) then we
+simply map it to an empty list. E.g.::
+  {
+    "scope_a": ["claim1", "claim2"],
+    "scope_b": []
+  }
+
+--------------
+allowed_scopes
+--------------
+
+A list with the scopes that are allowed to be used (defaults to the keys in the
+clients scopes_mapping).

--- a/docs/source/contents/conf.rst
+++ b/docs/source/contents/conf.rst
@@ -54,7 +54,6 @@ sub_funcs
 Optional. Functions involved in *sub*ject value creation.
 
 
-
 scopes_mapping
 ##############
 
@@ -73,6 +72,12 @@ allowed_scopes
 ##############
 
 A list with the scopes that are allowed to be used (defaults to the keys in scopes_mapping).
+
+
+advertised_scopes
+#################
+
+A list with the scopes that will be advertised in the well-known endpoint (defaults to allowed_scopes).
 
 
 ------

--- a/src/oidcop/authz/__init__.py
+++ b/src/oidcop/authz/__init__.py
@@ -80,8 +80,10 @@ class AuthzHandling(object):
             grant.resources = resources
 
         # After this is where user consent should be handled
-        scopes = request.get("scope", [])
-        grant.scope = scopes
+        scopes = grant.scope
+        if not scopes:
+            scopes = request.get("scope", [])
+            grant.scope = scopes
         grant.claims = self.server_get("endpoint_context").claims_interface.get_claims_all_usage(
             session_id=session_id, scopes=scopes
         )

--- a/src/oidcop/configure.py
+++ b/src/oidcop/configure.py
@@ -10,6 +10,7 @@ from typing import Optional
 from typing import Union
 
 from oidcop.logging import configure_logging
+from oidcop.scopes import SCOPE2CLAIMS
 from oidcop.utils import load_yaml_config
 
 DEFAULT_FILE_ATTRIBUTE_NAMES = [
@@ -78,6 +79,7 @@ OP_DEFAULT_CONFIG = {
         "refresh": {"class": "oidcop.token.jwt_token.JWTToken", "kwargs": {"lifetime": 86400}, },
         "id_token": {"class": "oidcop.token.id_token.IDToken", "kwargs": {}},
     },
+    "scopes_mapping": SCOPE2CLAIMS,
 }
 
 AS_DEFAULT_CONFIG = copy.deepcopy(OP_DEFAULT_CONFIG)
@@ -274,12 +276,39 @@ class OPConfiguration(EntityConfiguration):
     "Provider configuration"
     default_config = OP_DEFAULT_CONFIG
     parameter = EntityConfiguration.parameter.copy()
-    parameter.update({
-        "id_token": None,
-        "login_hint2acrs": {},
-        "login_hint_lookup": None,
-        "sub_func": {}
-    })
+    parameter.update(
+        {
+            "id_token": None,
+            "login_hint2acrs": {},
+            "login_hint_lookup": None,
+            "sub_func": {},
+            "scopes_mapping": {},
+            "scopes_supported": None,
+            "advertised_scopes": None,
+        }
+    )
+
+    def __init__(
+        self,
+        conf: Dict,
+        base_path: Optional[str] = "",
+        entity_conf: Optional[List[dict]] = None,
+        domain: Optional[str] = "",
+        port: Optional[int] = 0,
+        file_attributes: Optional[List[str]] = None,
+    ):
+        super().__init__(
+            conf=conf,
+            base_path=base_path,
+            entity_conf=entity_conf,
+            domain=domain,
+            port=port,
+            file_attributes=file_attributes,
+        )
+        scopes_mapping = self.scopes_mapping
+        if "advertised_scopes" not in self:
+            self["advertised_scopes"] = list(scopes_mapping.keys())
+
 
 class ASConfiguration(EntityConfiguration):
     "Authorization server configuration"

--- a/src/oidcop/oidc/add_on/custom_scopes.py
+++ b/src/oidcop/oidc/add_on/custom_scopes.py
@@ -10,17 +10,22 @@ def add_custom_scopes(endpoint, **kwargs):
     :param endpoint: A dictionary with endpoint instances as values
     """
     # Just need an endpoint, anyone will do
+    LOGGER.warning(
+        "The custom_scopes add on is deprecated. The `scopes_mapping` config "
+        "option should be used instead."
+    )
     _endpoint = list(endpoint.values())[0]
 
     _scopes2claims = SCOPE2CLAIMS.copy()
     _scopes2claims.update(kwargs)
     _context = _endpoint.server_get("endpoint_context")
-    _context.scope2claims = _scopes2claims
+    _context.scopes_handler.scopes_mapping = _scopes2claims
 
     pi = _context.provider_info
     _scopes = set(pi.get("scopes_supported", []))
     _scopes.update(set(kwargs.keys()))
     pi["scopes_supported"] = list(_scopes)
+    _context.scopes_handler.allowed_scopes = pi["scopes_supported"]
 
     _claims = set(pi.get("claims_supported", []))
     for vals in kwargs.values():

--- a/src/oidcop/server.py
+++ b/src/oidcop/server.py
@@ -67,7 +67,12 @@ class Server(ImpExp):
         ImpExp.__init__(self)
         self.conf = conf
         self.endpoint_context = EndpointContext(
-            conf=conf, keyjar=keyjar, cwd=cwd, cookie_handler=cookie_handler, httpc=httpc,
+            conf=conf,
+            server_get=self.server_get,
+            keyjar=keyjar,
+            cwd=cwd,
+            cookie_handler=cookie_handler,
+            httpc=httpc,
         )
         self.endpoint_context.authz = self.do_authz()
 

--- a/src/oidcop/session/claims.py
+++ b/src/oidcop/session/claims.py
@@ -4,8 +4,8 @@ from typing import Union
 
 from oidcmsg.oidc import OpenIDSchema
 
-from oidcop.exception import ServiceError
 from oidcop.exception import ImproperlyConfigured
+from oidcop.exception import ServiceError
 from oidcop.scopes import convert_scopes2claims
 
 logger = logging.getLogger(__name__)
@@ -113,9 +113,7 @@ class ClaimsInterface:
 
         if add_claims_by_scope:
             if scopes:
-                _scopes = _context.scopes_handler.filter_scopes(client_id, _context, scopes)
-
-                _claims = convert_scopes2claims(_scopes, scope2claim_map=_context.scope2claims)
+                _claims = _context.scopes_handler.scopes_to_claims(scopes, client_id=client_id)
                 claims.update(_claims)
 
         # Bring in claims specification from the authorization request

--- a/src/oidcop/session/claims.py
+++ b/src/oidcop/session/claims.py
@@ -112,7 +112,7 @@ class ClaimsInterface:
 
         if add_claims_by_scope:
             if scopes is None:
-                scopes = auth_req.get("scopes")
+                scopes = auth_req.get("scope")
             if scopes:
                 _claims = _context.scopes_handler.scopes_to_claims(scopes, client_id=client_id)
                 claims.update(_claims)
@@ -162,12 +162,12 @@ class ClaimsInterface:
         return claims
 
     def get_claims_all_usage_from_request(
-        self, auth_req: dict, scopes: str
+        self, auth_req: dict, scopes: str = None, client_id: str = None
     ) -> dict:
         _claims = {}
         for usage in self.claims_release_points:
             _claims[usage] = self.get_claims_from_request(
-                auth_req, usage, scopes
+                auth_req, usage, scopes=scopes, client_id=client_id
             )
         return _claims
 

--- a/tests/test_01_claims.py
+++ b/tests/test_01_claims.py
@@ -141,33 +141,24 @@ class TestEndpoint(object):
         )
 
     def test_authorization_request_id_token_claims(self):
-        session_id = self._create_session(AREQ)
-
-        claims = self.claims_interface.authorization_request_claims(session_id, "id_token")
+        claims = self.claims_interface.authorization_request_claims(AREQ, "id_token")
         assert claims == {}
 
     def test_authorization_request_id_token_claims_2(self):
-        session_id = self._create_session(AREQ_2)
-        claims = self.claims_interface.authorization_request_claims(session_id, "id_token")
+        claims = self.claims_interface.authorization_request_claims(AREQ_2, "id_token")
         assert claims
         assert set(claims.keys()) == {"nickname"}
 
     def test_authorization_request_userinfo_claims(self):
-        session_id = self._create_session(AREQ)
-
-        claims = self.claims_interface.authorization_request_claims(session_id, "userinfo")
+        claims = self.claims_interface.authorization_request_claims(AREQ, "userinfo")
         assert claims == {}
 
     def test_authorization_request_userinfo_claims_2(self):
-        session_id = self._create_session(AREQ_2)
-
-        claims = self.claims_interface.authorization_request_claims(session_id, "userinfo")
+        claims = self.claims_interface.authorization_request_claims(AREQ_2, "userinfo")
         assert claims == {}
 
     def test_authorization_request_userinfo_claims_3(self):
-        session_id = self._create_session(AREQ_3)
-
-        claims = self.claims_interface.authorization_request_claims(session_id, "userinfo")
+        claims = self.claims_interface.authorization_request_claims(AREQ_3, "userinfo")
         assert set(claims.keys()) == {"name", "email", "email_verified"}
 
     @pytest.mark.parametrize("usage", ["id_token", "userinfo", "introspection", "token"])

--- a/tests/test_06_session_manager.py
+++ b/tests/test_06_session_manager.py
@@ -200,11 +200,12 @@ class TestSessionManager:
         )
 
     def test_grant(self):
-        grant = Grant()
+        sid = self._create_session(AUTH_REQ)
+        grant = self.session_manager.get_grant(sid)
         assert grant.issued_token == []
         assert grant.is_active() is True
 
-        code = self._mint_token("authorization_code", grant, self.dummy_session_id)
+        code = self._mint_token("authorization_code", grant, sid)
         assert isinstance(code, AuthorizationCode)
         assert code.is_active()
         assert len(grant.issued_token) == 1

--- a/tests/test_24_oauth2_token_endpoint.py
+++ b/tests/test_24_oauth2_token_endpoint.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+import pytest
 from cryptojwt import JWT
 from cryptojwt.key_jar import build_keyjar
 from oidcmsg.oidc import AccessTokenRequest
@@ -8,7 +9,6 @@ from oidcmsg.oidc import AuthorizationRequest
 from oidcmsg.oidc import RefreshAccessTokenRequest
 from oidcmsg.oidc import TokenErrorResponse
 from oidcmsg.time_util import utc_time_sans_frac
-import pytest
 
 from oidcop import JWT_BEARER
 from oidcop.authn_event import create_authn_event
@@ -361,9 +361,7 @@ class TestEndpoint(object):
     def test_refresh_grant_disallowed_per_client(self):
         areq = AUTH_REQ.copy()
         areq["scope"] = ["email"]
-        self.endpoint_context.cdb["client_1"]["grant_types_supported"] = [
-            "authorization_code"
-        ]
+        self.endpoint_context.cdb["client_1"]["grant_types_supported"] = ["authorization_code"]
 
         session_id = self._create_session(areq)
         grant = self.endpoint_context.authz(session_id, areq)

--- a/tests/test_24_oidc_authorization_endpoint.py
+++ b/tests/test_24_oidc_authorization_endpoint.py
@@ -825,14 +825,18 @@ class TestEndpoint(object):
 
     @pytest.mark.parametrize("exp_in", [360, "360", 0])
     def test_mint_token_exp_at(self, exp_in):
-        grant = Grant()
+        request = AuthorizationRequest(
+            client_id="client_1",
+            response_type=["code"],
+            redirect_uri="https://example.com/cb",
+            state="state",
+            scope="openid",
+        )
+        sid = self._create_session(request)
+        grant = self.session_manager.get_grant(sid)
         grant.usage_rules = {"authorization_code": {"expires_in": exp_in}}
 
-        DUMMY_SESSION_ID = self.session_manager.encrypted_session_id(
-            "user_id", "client_id", "grant.id"
-        )
-
-        code = self.endpoint.mint_token("authorization_code", grant, DUMMY_SESSION_ID)
+        code = self.endpoint.mint_token("authorization_code", grant, sid)
         if exp_in in [360, "360"]:
             assert code.expires_at
         else:

--- a/tests/test_50_persistence.py
+++ b/tests/test_50_persistence.py
@@ -2,10 +2,10 @@ import json
 import os
 import shutil
 
+import pytest
 from cryptojwt.jwt import utc_time_sans_frac
 from oidcmsg.oidc import AccessTokenRequest
 from oidcmsg.oidc import AuthorizationRequest
-import pytest
 
 from oidcop import user_info
 from oidcop.authn_event import create_authn_event
@@ -16,6 +16,7 @@ from oidcop.oidc.authorization import Authorization
 from oidcop.oidc.provider_config import ProviderConfiguration
 from oidcop.oidc.registration import Registration
 from oidcop.oidc.token import Token
+from oidcop.scopes import SCOPE2CLAIMS
 from oidcop.server import Server
 from oidcop.user_authn.authn_context import INTERNETPROTOCOLPASSWORD
 from oidcop.user_info import UserInfo
@@ -136,21 +137,17 @@ ENDPOINT_CONTEXT_CONFIG = {
         }
     },
     "template_dir": "template",
-    "add_on": {
-        "custom_scopes": {
-            "function": "oidcop.oidc.add_on.custom_scopes.add_custom_scopes",
-            "kwargs": {
-                "research_and_scholarship": [
-                    "name",
-                    "given_name",
-                    "family_name",
-                    "email",
-                    "email_verified",
-                    "sub",
-                    "eduperson_scoped_affiliation",
-                ]
-            },
-        }
+    "scopes_mapping": {
+        **SCOPE2CLAIMS,
+        "research_and_scholarship": [
+            "name",
+            "given_name",
+            "family_name",
+            "email",
+            "email_verified",
+            "sub",
+            "eduperson_scoped_affiliation",
+        ],
     },
     "authz": {
         "class": AuthzHandling,
@@ -401,8 +398,8 @@ class TestEndpoint(object):
         _auth_req = AUTH_REQ.copy()
         _auth_req["scope"] = ["openid", "research_and_scholarship"]
 
-        session_id = self._create_session(AUTH_REQ, index=2)
-        grant = self.endpoint[2].server_get("endpoint_context").authz(session_id, AUTH_REQ)
+        session_id = self._create_session(_auth_req, index=2)
+        grant = self.endpoint[2].server_get("endpoint_context").authz(session_id, _auth_req)
 
         self._dump_restore(2, 1)
 


### PR DESCRIPTION
I went ahead and implemented the behavior described in https://github.com/IdentityPython/oidc-op/issues/127. I hope you agree with my approach.

If this PR is merged then the `custom_scopes` add on should be deprecated. I didn't delete it in case someone uses it in his installation but added a warning.

Closes #127 