### PR TITLE
Rename scopes config

### DIFF
--- a/docs/source/contents/conf.rst
+++ b/docs/source/contents/conf.rst
@@ -54,7 +54,7 @@ sub_funcs
 Optional. Functions involved in *sub*ject value creation.
 
 
-scopes_mapping
+scopes_to_claims
 ##############
 
 A dict defining the scopes that are allowed to be used per client and the claims
@@ -71,7 +71,7 @@ simply map it to an empty list. E.g.::
 allowed_scopes
 ##############
 
-A list with the scopes that are allowed to be used (defaults to the keys in scopes_mapping).
+A list with the scopes that are allowed to be used (defaults to the keys in scopes_to_claims).
 
 
 scopes_supported
@@ -736,7 +736,7 @@ grant_types_supported
 Configure the allowed grant types on the token endpoint.
 
 --------------
-scopes_mapping
+scopes_to_claims
 --------------
 
 A dict defining the scopes that are allowed to be used per client and the claims
@@ -753,4 +753,4 @@ allowed_scopes
 --------------
 
 A list with the scopes that are allowed to be used (defaults to the keys in the
-clients scopes_mapping).
+clients scopes_to_claims).

--- a/docs/source/contents/conf.rst
+++ b/docs/source/contents/conf.rst
@@ -74,8 +74,8 @@ allowed_scopes
 A list with the scopes that are allowed to be used (defaults to the keys in scopes_mapping).
 
 
-advertised_scopes
-#################
+scopes_supported
+################
 
 A list with the scopes that will be advertised in the well-known endpoint (defaults to allowed_scopes).
 

--- a/src/oidcop/configure.py
+++ b/src/oidcop/configure.py
@@ -79,7 +79,7 @@ OP_DEFAULT_CONFIG = {
         "refresh": {"class": "oidcop.token.jwt_token.JWTToken", "kwargs": {"lifetime": 86400}, },
         "id_token": {"class": "oidcop.token.id_token.IDToken", "kwargs": {}},
     },
-    "scopes_mapping": SCOPE2CLAIMS,
+    "scopes_to_claims": SCOPE2CLAIMS,
 }
 
 AS_DEFAULT_CONFIG = copy.deepcopy(OP_DEFAULT_CONFIG)
@@ -282,7 +282,7 @@ class OPConfiguration(EntityConfiguration):
             "login_hint2acrs": {},
             "login_hint_lookup": None,
             "sub_func": {},
-            "scopes_mapping": {},
+            "scopes_to_claims": {},
         }
     )
 
@@ -303,7 +303,7 @@ class OPConfiguration(EntityConfiguration):
             port=port,
             file_attributes=file_attributes,
         )
-        scopes_mapping = self.scopes_mapping
+        scopes_to_claims = self.scopes_to_claims
 
 
 class ASConfiguration(EntityConfiguration):

--- a/src/oidcop/configure.py
+++ b/src/oidcop/configure.py
@@ -283,8 +283,6 @@ class OPConfiguration(EntityConfiguration):
             "login_hint_lookup": None,
             "sub_func": {},
             "scopes_mapping": {},
-            "scopes_supported": None,
-            "advertised_scopes": None,
         }
     )
 
@@ -306,8 +304,6 @@ class OPConfiguration(EntityConfiguration):
             file_attributes=file_attributes,
         )
         scopes_mapping = self.scopes_mapping
-        if "advertised_scopes" not in self:
-            self["advertised_scopes"] = list(scopes_mapping.keys())
 
 
 class ASConfiguration(EntityConfiguration):

--- a/src/oidcop/endpoint_context.py
+++ b/src/oidcop/endpoint_context.py
@@ -257,7 +257,7 @@ class EndpointContext(OidcContext):
             self.scopes_handler = Scopes(
                 self.server_get,
                 allowed_scopes=self.conf.get("allowed_scopes"),
-                scopes_mapping=self.conf.get("scopes_mapping"),
+                scopes_to_claims=self.conf.get("scopes_to_claims"),
             )
 
     def do_add_on(self, endpoints):

--- a/src/oidcop/oidc/add_on/custom_scopes.py
+++ b/src/oidcop/oidc/add_on/custom_scopes.py
@@ -11,7 +11,7 @@ def add_custom_scopes(endpoint, **kwargs):
     """
     # Just need an endpoint, anyone will do
     LOGGER.warning(
-        "The custom_scopes add on is deprecated. The `scopes_mapping` config "
+        "The custom_scopes add on is deprecated. The `scopes_to_claims` config "
         "option should be used instead."
     )
     _endpoint = list(endpoint.values())[0]
@@ -19,7 +19,7 @@ def add_custom_scopes(endpoint, **kwargs):
     _scopes2claims = SCOPE2CLAIMS.copy()
     _scopes2claims.update(kwargs)
     _context = _endpoint.server_get("endpoint_context")
-    _context.scopes_handler.scopes_mapping = _scopes2claims
+    _context.scopes_handler.scopes_to_claims = _scopes2claims
 
     pi = _context.provider_info
     _scopes = set(pi.get("scopes_supported", []))

--- a/src/oidcop/scopes.py
+++ b/src/oidcop/scopes.py
@@ -45,13 +45,13 @@ def convert_scopes2claims(scopes, allowed_claims=None, scope2claim_map=None):
 
 
 class Scopes:
-    def __init__(self, server_get, allowed_scopes=None, scopes_mapping=None):
+    def __init__(self, server_get, allowed_scopes=None, scopes_to_claims=None):
         self.server_get = server_get
-        if not scopes_mapping:
-            scopes_mapping = dict(SCOPE2CLAIMS)
-        self.scopes_mapping = scopes_mapping
+        if not scopes_to_claims:
+            scopes_to_claims = dict(SCOPE2CLAIMS)
+        self._scopes_to_claims = scopes_to_claims
         if not allowed_scopes:
-            allowed_scopes = list(scopes_mapping.keys())
+            allowed_scopes = list(scopes_to_claims.keys())
         self.allowed_scopes = allowed_scopes
 
     def get_allowed_scopes(self, client_id=None):
@@ -67,8 +67,8 @@ class Scopes:
             if client is not None:
                 if "allowed_scopes" in client:
                     allowed_scopes = client.get("allowed_scopes")
-                elif "scopes_mapping" in client:
-                    allowed_scopes = list(client.get("scopes_mapping").keys())
+                elif "scopes_to_claims" in client:
+                    allowed_scopes = list(client.get("scopes_to_claims").keys())
 
         return allowed_scopes
 
@@ -79,21 +79,21 @@ class Scopes:
         :param client_id: The client identifier
         :returns: Dict of scopes to claims. Can be empty.
         """
-        scopes_mapping = self.scopes_mapping
+        scopes_to_claims = self._scopes_to_claims
         if client_id:
             client = self.server_get("endpoint_context").cdb.get(client_id)
             if client is not None:
-                scopes_mapping = client.get("scopes_mapping", scopes_mapping)
-        return scopes_mapping
+                scopes_to_claims = client.get("scopes_to_claims", scopes_to_claims)
+        return scopes_to_claims
 
     def filter_scopes(self, scopes, client_id=None):
         allowed_scopes = self.get_allowed_scopes(client_id)
         return [s for s in scopes if s in allowed_scopes]
 
-    def scopes_to_claims(self, scopes, scopes_mapping=None, client_id=None):
-        if not scopes_mapping:
-            scopes_mapping = self.get_scopes_mapping(client_id)
+    def scopes_to_claims(self, scopes, scopes_to_claims=None, client_id=None):
+        if not scopes_to_claims:
+            scopes_to_claims = self.get_scopes_mapping(client_id)
 
         scopes = self.filter_scopes(scopes, client_id)
 
-        return convert_scopes2claims(scopes, scope2claim_map=scopes_mapping)
+        return convert_scopes2claims(scopes, scope2claim_map=scopes_to_claims)

--- a/tests/test_07_userinfo.py
+++ b/tests/test_07_userinfo.py
@@ -440,7 +440,7 @@ class TestCollectUserInfoCustomScopes:
                     },
                 },
             },
-            "scopes_mapping": {
+            "scopes_to_claims": {
                 "openid": ["sub"],
                 "research_and_scholarship": [
                     "name",
@@ -521,13 +521,13 @@ class TestCollectUserInfoCustomScopes:
         }
 
     def test_collect_user_info_scope_mapping_per_client(self, conf):
-        conf["scopes_mapping"] = SCOPE2CLAIMS
+        conf["scopes_to_claims"] = SCOPE2CLAIMS
         server = Server(conf)
         endpoint_context = server.endpoint_context
         self.session_manager = endpoint_context.session_manager
         claims_interface = endpoint_context.claims_interface
         endpoint_context.cdb["client1"] = {
-            "scopes_mapping": {
+            "scopes_to_claims": {
                 "openid": ["sub"],
                 "research_and_scholarship": [
                     "name",

--- a/tests/test_22_oidc_provider_config_endpoint.py
+++ b/tests/test_22_oidc_provider_config_endpoint.py
@@ -108,7 +108,7 @@ class TestEndpoint(object):
         }
         assert ("Content-type", "application/json; charset=utf-8") in msg["http_headers"]
 
-    def test_advertised_scopes(self, conf):
+    def test_scopes_supported(self, conf):
         scopes_supported = ["openid", "random", "profile"]
         conf["capabilities"]["scopes_supported"] = scopes_supported
 

--- a/tests/test_26_oidc_userinfo_endpoint.py
+++ b/tests/test_26_oidc_userinfo_endpoint.py
@@ -149,7 +149,7 @@ class TestEndpoint(object):
 
             },
             "template_dir": "template",
-            "scopes_mapping": {
+            "scopes_to_claims": {
                 **SCOPE2CLAIMS,
                 "research_and_scholarship": [
                     "name",
@@ -317,7 +317,7 @@ class TestEndpoint(object):
         res = self.endpoint.do_response(request=_req, **args)
         assert res
 
-    def test_scopes_mapping(self):
+    def test_scopes_to_claims(self):
         _auth_req = AUTH_REQ.copy()
         _auth_req["scope"] = ["openid", "research_and_scholarship"]
 
@@ -347,8 +347,8 @@ class TestEndpoint(object):
             "sub",
         }
 
-    def test_scopes_mapping_per_client(self):
-        self.endpoint_context.cdb["client_1"]["scopes_mapping"] = {
+    def test_scopes_to_claims_per_client(self):
+        self.endpoint_context.cdb["client_1"]["scopes_to_claims"] = {
             **SCOPE2CLAIMS,
             "research_and_scholarship_2": [
                 "name",
@@ -415,7 +415,7 @@ class TestEndpoint(object):
         assert set(args["response_args"].keys()) == {"sub"}
 
     def test_allowed_scopes_per_client(self):
-        self.endpoint_context.cdb["client_1"]["scopes_mapping"] = {
+        self.endpoint_context.cdb["client_1"]["scopes_to_claims"] = {
             **SCOPE2CLAIMS,
             "research_and_scholarship_2": [
                 "name",

--- a/tests/test_50_persistence.py
+++ b/tests/test_50_persistence.py
@@ -137,7 +137,7 @@ ENDPOINT_CONTEXT_CONFIG = {
         }
     },
     "template_dir": "template",
-    "scopes_mapping": {
+    "scopes_to_claims": {
         **SCOPE2CLAIMS,
         "research_and_scholarship": [
             "name",


### PR DESCRIPTION
As described in https://github.com/IdentityPython/oidc-op/issues/127#issuecomment-922864256

Rename `scopes_mapping` to `scopes_to_claims`
Rename `advertised_scopes` to `scopes_supported`