### PR TITLE
Add parameter to revoke old refresh token upon issuing new

### DIFF
--- a/docs/source/contents/conf.rst
+++ b/docs/source/contents/conf.rst
@@ -339,8 +339,9 @@ An example::
               "client_secret_post",
               "client_secret_basic",
               "client_secret_jwt",
-              "private_key_jwt"
-            ]
+              "private_key_jwt",
+            ],
+            "revoke_refresh_on_issue": True
           }
         },
         "userinfo": {
@@ -754,3 +755,8 @@ allowed_scopes
 
 A list with the scopes that are allowed to be used (defaults to the keys in the
 clients scopes_to_claims).
+
+-----------------------
+revoke_refresh_on_issue
+-----------------------
+Configure whether to revoke the refresh token that was used to issue a new refresh token

--- a/src/oidcop/oauth2/token.py
+++ b/src/oidcop/oauth2/token.py
@@ -287,6 +287,17 @@ class RefreshTokenHelper(TokenEndpointHelper):
 
         token.register_usage()
 
+        if ("client_id" in req
+            and req["client_id"] in _context.cdb
+            and "revoke_refresh_on_issue" in _context.cdb[req["client_id"]]
+        ):
+            revoke_refresh = _context.cdb[req["client_id"]].get("revoke_refresh_on_issue")
+        else:
+            revoke_refresh = self.endpoint.revoke_refresh_on_issue
+
+        if revoke_refresh:
+            token.revoke()
+
         return _resp
 
     def post_parse_request(
@@ -365,6 +376,7 @@ class Token(Endpoint):
         self.allow_refresh = False
         self.new_refresh_token = new_refresh_token
         self.configure_grant_types(kwargs.get("grant_types_supported"))
+        self.revoke_refresh_on_issue = kwargs.get("revoke_refresh_on_issue", False)
 
     def configure_grant_types(self, grant_types_supported):
         if grant_types_supported is None:

--- a/tests/test_24_oauth2_token_endpoint.py
+++ b/tests/test_24_oauth2_token_endpoint.py
@@ -398,6 +398,7 @@ class TestEndpoint(object):
         grant = self.endpoint_context.authz(session_id, areq)
         code = self._mint_code(grant, areq["client_id"])
 
+        self.token_endpoint.revoke_refresh_on_issue = False
         _cntx = self.endpoint_context
 
         _token_request = TOKEN_REQ_DICT.copy()
@@ -423,8 +424,7 @@ class TestEndpoint(object):
         _2nd_request = REFRESH_TOKEN_REQ.copy()
         _2nd_request["refresh_token"] = _resp["response_args"]["refresh_token"]
         _2nd_req = self.token_endpoint.parse_request(_request.to_json())
-        _2nd_resp = self.token_endpoint.process_request(request=_req, issue_refresh=True)
-
+        _2nd_resp = self.token_endpoint.process_request(request=_2nd_req, issue_refresh=True)
         assert set(_2nd_resp.keys()) == {"cookie", "response_args", "http_headers"}
         assert set(_2nd_resp["response_args"].keys()) == {
             "access_token",
@@ -474,6 +474,82 @@ class TestEndpoint(object):
         assert "refresh_token" in _3rd_resp["response_args"]
 
         assert first_refresh_token != second_refresh_token
+
+    def test_revoke_on_issue_refresh_token(self, conf):
+        self.endpoint_context.cdb["client_1"] = {
+            "client_secret": "hemligt",
+            "redirect_uris": [("https://example.com/cb", None)],
+            "client_salt": "salted",
+            "endpoint_auth_method": "client_secret_post",
+            "response_types": ["code", "token", "code id_token", "id_token"],
+        }
+
+        self.token_endpoint.revoke_refresh_on_issue = True
+        areq = AUTH_REQ.copy()
+        areq["scope"] = ["email"]
+
+        session_id = self._create_session(areq)
+        grant = self.endpoint_context.authz(session_id, areq)
+        code = self._mint_code(grant, areq["client_id"])
+
+        _token_request = TOKEN_REQ_DICT.copy()
+        _token_request["code"] = code.value
+        _req = self.token_endpoint.parse_request(_token_request)
+        _resp = self.token_endpoint.process_request(request=_req, issue_refresh=True)
+        assert "refresh_token" in _resp["response_args"]
+        first_refresh_token = _resp["response_args"]["refresh_token"]
+
+        _refresh_request = REFRESH_TOKEN_REQ.copy()
+        _refresh_request["refresh_token"] = first_refresh_token
+        _2nd_req = self.token_endpoint.parse_request(_refresh_request.to_json())
+        _2nd_resp = self.token_endpoint.process_request(request=_2nd_req, issue_refresh=True)
+        assert "refresh_token" in _2nd_resp["response_args"]
+        second_refresh_token = _2nd_resp["response_args"]["refresh_token"]
+
+        assert first_refresh_token != second_refresh_token
+        first_refresh_token = grant.get_token(first_refresh_token)
+        second_refresh_token = grant.get_token(second_refresh_token)
+        assert first_refresh_token.revoked is True
+        assert second_refresh_token.revoked is False
+
+    def test_revoke_on_issue_refresh_token_per_client(self, conf):
+        self.endpoint_context.cdb["client_1"] = {
+            "client_secret": "hemligt",
+            "redirect_uris": [("https://example.com/cb", None)],
+            "client_salt": "salted",
+            "endpoint_auth_method": "client_secret_post",
+            "response_types": ["code", "token", "code id_token", "id_token"],
+        }
+        self.endpoint_context.cdb[AUTH_REQ["client_id"]]["revoke_refresh_on_issue"] = True
+        areq = AUTH_REQ.copy()
+        areq["scope"] = ["openid", "offline_access"]
+
+        session_id = self._create_session(areq)
+        grant = self.endpoint_context.authz(session_id, areq)
+        code = self._mint_code(grant, areq["client_id"])
+
+        _token_request = TOKEN_REQ_DICT.copy()
+        _token_request["code"] = code.value
+        _req = self.token_endpoint.parse_request(_token_request)
+        _resp = self.token_endpoint.process_request(request=_req, issue_refresh=True)
+        assert "refresh_token" in _resp["response_args"]
+        first_refresh_token = _resp["response_args"]["refresh_token"]
+
+        _refresh_request = REFRESH_TOKEN_REQ.copy()
+        _refresh_request["refresh_token"] = first_refresh_token
+        _2nd_req = self.token_endpoint.parse_request(_refresh_request.to_json())
+        _2nd_resp = self.token_endpoint.process_request(request=_2nd_req, issue_refresh=True)
+        assert "refresh_token" in _2nd_resp["response_args"]
+        second_refresh_token = _2nd_resp["response_args"]["refresh_token"]
+
+        _2d_refresh_request = REFRESH_TOKEN_REQ.copy()
+        _2d_refresh_request["refresh_token"] = second_refresh_token
+
+        assert first_refresh_token != second_refresh_token
+        first_refresh_token = grant.get_token(first_refresh_token)
+        second_refresh_token = grant.get_token(second_refresh_token)
+        assert first_refresh_token.revoked is True
+        assert second_refresh_token.revoked is False
 
     def test_refresh_scopes(self):
         areq = AUTH_REQ.copy()

--- a/tests/test_35_oidc_token_endpoint.py
+++ b/tests/test_35_oidc_token_endpoint.py
@@ -117,7 +117,7 @@ def conf():
             },
             "refresh": {
                 "class": "oidcop.token.jwt_token.JWTToken",
-                "kwargs": {"lifetime": 3600, "aud": ["https://example.org/appl"], },
+                "kwargs": {"lifetime": 3600, "aud": ["https://example.org/appl"]},
             },
             "id_token": {"class": "oidcop.token.id_token.IDToken", "kwargs": {}},
         },
@@ -390,7 +390,7 @@ class TestEndpoint(_TestEndpoint):
         session_id = self._create_session(areq)
         grant = self.endpoint_context.authz(session_id, areq)
         code = self._mint_code(grant, areq["client_id"])
-
+        self.token_endpoint.revoke_refresh_on_issue = False
         _cntx = self.endpoint_context
 
         _token_request = TOKEN_REQ_DICT.copy()
@@ -760,6 +760,84 @@ class TestEndpoint(_TestEndpoint):
         assert "refresh_token" in _3rd_resp["response_args"]
 
         assert first_refresh_token != second_refresh_token
+
+    def test_revoke_on_issue_refresh_token(self, conf):
+        self.endpoint_context.cdb["client_1"] = {
+            "client_secret": "hemligt",
+            "redirect_uris": [("https://example.com/cb", None)],
+            "client_salt": "salted",
+            "endpoint_auth_method": "client_secret_post",
+            "response_types": ["code", "token", "code id_token", "id_token"],
+        }
+        self.token_endpoint.revoke_refresh_on_issue = True
+        areq = AUTH_REQ.copy()
+        areq["scope"] = ["openid", "offline_access"]
+
+        session_id = self._create_session(areq)
+        grant = self.endpoint_context.authz(session_id, areq)
+        code = self._mint_code(grant, areq["client_id"])
+
+        _token_request = TOKEN_REQ_DICT.copy()
+        _token_request["code"] = code.value
+        _req = self.token_endpoint.parse_request(_token_request)
+        _resp = self.token_endpoint.process_request(request=_req, issue_refresh=True)
+        assert "refresh_token" in _resp["response_args"]
+        first_refresh_token = _resp["response_args"]["refresh_token"]
+
+        _refresh_request = REFRESH_TOKEN_REQ.copy()
+        _refresh_request["refresh_token"] = first_refresh_token
+        _2nd_req = self.token_endpoint.parse_request(_refresh_request.to_json())
+        _2nd_resp = self.token_endpoint.process_request(request=_2nd_req, issue_refresh=True)
+        assert "refresh_token" in _2nd_resp["response_args"]
+        second_refresh_token = _2nd_resp["response_args"]["refresh_token"]
+
+        _2d_refresh_request = REFRESH_TOKEN_REQ.copy()
+        _2d_refresh_request["refresh_token"] = second_refresh_token
+
+        assert first_refresh_token != second_refresh_token
+        first_refresh_token = grant.get_token(first_refresh_token)
+        second_refresh_token = grant.get_token(second_refresh_token)
+        assert first_refresh_token.revoked is True
+        assert second_refresh_token.revoked is False
+
+    def test_revoke_on_issue_refresh_token_per_client(self, conf):
+        self.endpoint_context.cdb["client_1"] = {
+            "client_secret": "hemligt",
+            "redirect_uris": [("https://example.com/cb", None)],
+            "client_salt": "salted",
+            "endpoint_auth_method": "client_secret_post",
+            "response_types": ["code", "token", "code id_token", "id_token"],
+        }
+        self.endpoint_context.cdb[AUTH_REQ["client_id"]]["revoke_refresh_on_issue"] = True
+        areq = AUTH_REQ.copy()
+        areq["scope"] = ["openid", "offline_access"]
+
+        session_id = self._create_session(areq)
+        grant = self.endpoint_context.authz(session_id, areq)
+        code = self._mint_code(grant, areq["client_id"])
+
+        _token_request = TOKEN_REQ_DICT.copy()
+        _token_request["code"] = code.value
+        _req = self.token_endpoint.parse_request(_token_request)
+        _resp = self.token_endpoint.process_request(request=_req, issue_refresh=True)
+        assert "refresh_token" in _resp["response_args"]
+        first_refresh_token = _resp["response_args"]["refresh_token"]
+
+        _refresh_request = REFRESH_TOKEN_REQ.copy()
+        _refresh_request["refresh_token"] = first_refresh_token
+        _2nd_req = self.token_endpoint.parse_request(_refresh_request.to_json())
+        _2nd_resp = self.token_endpoint.process_request(request=_2nd_req, issue_refresh=True)
+        assert "refresh_token" in _2nd_resp["response_args"]
+        second_refresh_token = _2nd_resp["response_args"]["refresh_token"]
+
+        _2d_refresh_request = REFRESH_TOKEN_REQ.copy()
+        _2d_refresh_request["refresh_token"] = second_refresh_token
+
+        assert first_refresh_token != second_refresh_token
+        first_refresh_token = grant.get_token(first_refresh_token)
+        second_refresh_token = grant.get_token(second_refresh_token)
+        assert first_refresh_token.revoked is True
+        assert second_refresh_token.revoked is False
 
     def test_do_refresh_access_token_not_allowed(self):
         areq = AUTH_REQ.copy()


### PR DESCRIPTION
Introduce parameter `revoke_refresh_on_issue` in order to revoke the Refresh Token used to issue a new one.