### PR TITLE
Use configuration classes from oidcmsg.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Libraries :: Python Modules"],
     install_requires=[
-        "oidcmsg==1.5.3",
+        "oidcmsg==1.5.4",
         "pyyaml",
         "jinja2>=2.11.3",
         "responses>=0.13.0"

--- a/src/oidcop/cookie_handler.py
+++ b/src/oidcop/cookie_handler.py
@@ -14,6 +14,7 @@ from cryptojwt.jwe.aes import AES_GCMEncrypter
 from cryptojwt.jwe.utils import split_ctx_and_tag
 from cryptojwt.jwk.hmac import SYMKey
 from cryptojwt.jws.hmac import HMACSigner
+from cryptojwt.jwt import utc_time_sans_frac
 from cryptojwt.key_jar import init_key_jar
 from oidcmsg.time_util import epoch_in_a_while
 
@@ -31,13 +32,13 @@ LOGGER = logging.getLogger(__name__)
 
 class CookieHandler:
     def __init__(
-        self,
-        sign_key: Optional[SYMKey] = None,
-        enc_key: Optional[SYMKey] = None,
-        keys: Optional[dict] = None,
-        sign_alg: [str] = "SHA256",
-        name: Optional[dict] = None,
-        **kwargs,
+            self,
+            sign_key: Optional[SYMKey] = None,
+            enc_key: Optional[SYMKey] = None,
+            keys: Optional[dict] = None,
+            sign_alg: [str] = "SHA256",
+            name: Optional[dict] = None,
+            **kwargs,
     ):
 
         if keys:
@@ -101,7 +102,7 @@ class CookieHandler:
         if timestamp:
             timestamp = str(timestamp)
         else:
-            timestamp = str(int(time.time()))
+            timestamp = str(int(utc_time_sans_frac()))
 
         bytes_load = payload.encode("utf-8")
         bytes_timestamp = timestamp.encode("utf-8")
@@ -153,9 +154,9 @@ class CookieHandler:
             mac = base64.b64decode(b64_mac)
             verifier = HMACSigner(algorithm=self.sign_alg)
             if verifier.verify(
-                payload.encode("utf-8") + timestamp.encode("utf-8"),
-                mac,
-                self.sign_key.key,
+                    payload.encode("utf-8") + timestamp.encode("utf-8"),
+                    mac,
+                    self.sign_key.key,
             ):
                 return payload, timestamp
             else:
@@ -178,9 +179,9 @@ class CookieHandler:
             if len(p) == 3:
                 verifier = HMACSigner(algorithm=self.sign_alg)
                 if verifier.verify(
-                    payload.encode("utf-8") + timestamp.encode("utf-8"),
-                    base64.b64decode(p[2]),
-                    self.sign_key.key,
+                        payload.encode("utf-8") + timestamp.encode("utf-8"),
+                        base64.b64decode(p[2]),
+                        self.sign_key.key,
                 ):
                     return payload, timestamp
                 else:
@@ -190,13 +191,13 @@ class CookieHandler:
         return None
 
     def make_cookie_content(
-        self,
-        name: str,
-        value: str,
-        typ: Optional[str] = "",
-        timestamp: Optional[Union[int, str]] = "",
-        max_age: Optional[int] = 0,
-        **kwargs,
+            self,
+            name: str,
+            value: str,
+            typ: Optional[str] = "",
+            timestamp: Optional[Union[int, str]] = "",
+            max_age: Optional[int] = 0,
+            **kwargs,
     ) -> dict:
         """
         Create and return information to put in a cookie
@@ -210,7 +211,7 @@ class CookieHandler:
         """
 
         if not timestamp:
-            timestamp = str(int(time.time()))
+            timestamp = str(int(utc_time_sans_frac()))
 
         # create cookie payload
         if not value and not typ:

--- a/tests/test_00_configure.py
+++ b/tests/test_00_configure.py
@@ -1,11 +1,11 @@
 import json
 import os
 
+from oidcmsg.configure import Configuration
+from oidcmsg.configure import create_from_config_file
 import pytest
 
-from oidcop.configure import Configuration
 from oidcop.configure import OPConfiguration
-from oidcop.configure import create_from_config_file
 from oidcop.logging import configure_logging
 
 BASEDIR = os.path.abspath(os.path.dirname(__file__))
@@ -76,7 +76,7 @@ def test_op_configure_default():
     id_token_conf = configuration.get("id_token", {})
     assert set(id_token_conf.keys()) == {"kwargs", "class"}
     assert id_token_conf["kwargs"] == {
-        "base_claims": {"email": {"essential": True}, "email_verified": {"essential": True},}
+        "base_claims": {"email": {"essential": True}, "email_verified": {"essential": True}, }
     }
 
 
@@ -95,7 +95,7 @@ def test_op_configure_default_from_file():
     id_token_conf = configuration.get("id_token", {})
     assert set(id_token_conf.keys()) == {"kwargs", "class"}
     assert id_token_conf["kwargs"] == {
-        "base_claims": {"email": {"essential": True}, "email_verified": {"essential": True},}
+        "base_claims": {"email": {"essential": True}, "email_verified": {"essential": True}, }
     }
 
 

--- a/tests/test_04_token_handler.py
+++ b/tests/test_04_token_handler.py
@@ -3,9 +3,8 @@ import hashlib
 import hmac
 import os
 import secrets
-import time
 
-from cryptojwt.jwt import utc_time_sans_frac
+from oidcmsg.time_util import utc_time_sans_frac
 import pytest
 
 from oidcop.configure import OPConfiguration
@@ -105,8 +104,9 @@ class TestDefaultToken(object):
         _token = self.th("another_id")
         assert self.th.is_expired(_token) is False
 
-        when = time.time() + 900
-        assert self.th.is_expired(_token, int(when))
+        when = utc_time_sans_frac()
+        # has it expired 24 hours from now ?
+        assert self.th.is_expired(_token, int(when) + 86400)
 
 
 class TestTokenHandler(object):


### PR DESCRIPTION
Need to have oidcmsg 1.5.4 .
utc_time_sans_frac instead of time.time() since the later is unspecified when it comes to timezone.
Code dealing with configuration parsing that was present both in oidc-op and oidcmsg is now removed from oidc-op.