### PR TITLE
Project version behind pypi version. This to put them in sync.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [metadata]
 name = "oidcop"
-version = "2.3.0"
+version = "2.3.2"
 author = "Roland Hedberg"
 author_email = "roland@catalogix.se"
 description = "Python implementation of an OAuth2 AS and an OIDC Provider"

--- a/src/oidcop/__init__.py
+++ b/src/oidcop/__init__.py
@@ -1,6 +1,6 @@
 import secrets
 
-__version__ = "2.3.1"
+__version__ = "2.3.2"
 
 DEF_SIGN_ALG = {
     "id_token": "RS256",


### PR DESCRIPTION
For some reason library and pypi version was out of sync. 