### PR TITLE
Refactor client authentication

### DIFF
--- a/docs/source/contents/conf.rst
+++ b/docs/source/contents/conf.rst
@@ -831,6 +831,24 @@ The usage rules for each token type. E.g.::
         }
     }
 
+
+-------------------
+client_authn_method
+-------------------
+
+A list with the client authentication methods that are allowed for this client.
+
+This can be overriden per endpoint by adding the prefix `{endpoint_name}_`.
+E.g to define `client_authn_method` for a client only for the introspection
+endpoint we need to add to the client metadata::
+
+    {
+      "introspection_endpoint_client_authn_method": ["client_secret_basic", "client_secret_post"]
+    }
+
+NOTE: The client authentication methods defined per client MUST be a subset of the
+endpoint's authentication methods, else they are ignored.
+
 --------------
 pkce_essential
 --------------

--- a/docs/source/contents/conf.rst
+++ b/docs/source/contents/conf.rst
@@ -119,6 +119,30 @@ code_challenge_method
 The allowed code_challenge methods. The supported code challenge methods are:
 ``plain, S256, S384, S512``
 
+-------------------
+client_authn_method
+-------------------
+
+A dictionary with the allowed client authentication methods. The keys are the methods'
+names and and the values must be either a class or a path to a python class that will
+be imported and used to validate the client. The class should inherit from
+`oidcop.client_authn.ClientAuthnMethod` and it must implement the methods
+`is_usable` and `_verify`. You can then define which of these methods are allowed per
+endpoint by defining a list with the names of the methods allowed in the endpoint's
+capabilities. This can be overriden per client by defining `client_authn_method`
+in the client's metadata.
+
+Defaults to:
+ - none: `oidcop.client_authn.NoneAuthn`, no client authentication. Never use this in production
+ - public: `oidcop.client_authn.PublicAuthn`, used for public clients, requires only a valid`client_id` in the request
+ - client_secret_basic: `oidcop.client_authn.ClientSecretBasic`, see https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1
+ - client_secret_post: `oidcop.client_authn.ClientSecretPost`, see https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1
+ - bearer_header: `oidcop.client_authn.BearerHeader`, see https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
+ - bearer_body: `oidcop.client_authn.BearerBody`, see https://datatracker.ietf.org/doc/html/rfc6750#section-2.2
+ - client_secret_jwt: `oidcop.client_authn.ClientSecretJWT`, see https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
+ - private_key_jwt: `oidcop.client_authn.PrivateKeyJWT`, see https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
+ - request_param: `oidcop.client_authn.RequestParam`, see https://openid.net/specs/openid-connect-core-1_0.html#JWTRequests
+
 --------------
 authentication
 --------------

--- a/src/oidcop/client_authn.py
+++ b/src/oidcop/client_authn.py
@@ -432,11 +432,13 @@ def verify_client(
         except Exception as err:
             logger.info("Verifying auth using {} failed: {}".format(_method.tag, err))
 
+    client_id = auth_info.get("client_id")
+    if client_id is None:
+        raise ClientAuthenticationError("Failed to verify client")
+
     if also_known_as:
-        client_id = also_known_as[auth_info.get("client_id")]
+        client_id = also_known_as[client_id]
         auth_info["client_id"] = client_id
-    else:
-        client_id = auth_info.get("client_id")
 
     if client_id not in endpoint_context.cdb:
         raise UnknownClient("Unknown Client ID")
@@ -448,7 +450,7 @@ def verify_client(
         raise InvalidClient("Not valid client")
 
     # Validate that the used method is allowed for this client/endpoint
-    client_allowed_methods = _cinfo.get(f"{endpoint.endpoint_name}_client_authn_method")
+    client_allowed_methods = _cinfo.get(f"{endpoint.endpoint_name}_client_authn_method", _cinfo.get("client_authn_method"))
     if client_allowed_methods is not None and _method.tag not in client_allowed_methods:
         logger.info(
             f"Allowed methods for client: {client_id} at endpoint: {endpoint.name} are: "

--- a/src/oidcop/client_authn.py
+++ b/src/oidcop/client_authn.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+from collections import OrderedDict
 from typing import Callable
 from typing import Optional
 from typing import Union
@@ -20,42 +21,25 @@ from oidcop import JWT_BEARER
 from oidcop import sanitize
 from oidcop.endpoint_context import EndpointContext
 from oidcop.exception import BearerTokenAuthenticationError
+from oidcop.exception import ClientAuthenticationError
 from oidcop.exception import InvalidClient
-from oidcop.exception import MultipleUsage
-from oidcop.exception import NotForMe
+from oidcop.exception import InvalidToken
 from oidcop.exception import ToOld
+from oidcop.exception import UnAuthorizedClient
 from oidcop.exception import UnknownClient
-from oidcop.util import importer
 
 logger = logging.getLogger(__name__)
 
 __author__ = "roland hedberg"
 
 
-class AuthnFailure(Exception):
-    pass
-
-
-class NoMatchingKey(Exception):
-    pass
-
-
-class UnknownOrNoAuthnMethod(Exception):
-    pass
-
-
-class WrongAuthnMethod(Exception):
-    pass
-
-
 class ClientAuthnMethod(object):
-    def __init__(self, server_get):
-        """
-        :param server_get: A method that can be used to get general server information.
-        """
-        self.server_get = server_get
+    tag = None
 
-    def verify(self, **kwargs):
+    @classmethod
+    def _verify(
+        cls, endpoint_context, request=None, authorization_token=None, endpoint=None, **kwargs
+    ):
         """
         Verify authentication information in a request
         :param kwargs:
@@ -63,12 +47,39 @@ class ClientAuthnMethod(object):
         """
         raise NotImplementedError()
 
-    def is_usable(self, request=None, authorization_info=None):
+    @classmethod
+    def verify(
+        cls,
+        endpoint_context,
+        request=None,
+        authorization_token=None,
+        endpoint=None,
+        get_client_id_from_token=None,
+        **kwargs,
+    ):
+        """
+        Verify authentication information in a request
+        :param kwargs:
+        :return:
+        """
+        res = cls._verify(
+            endpoint_context,
+            request=request,
+            authorization_token=authorization_token,
+            endpoint=endpoint,
+            get_client_id_from_token=get_client_id_from_token,
+            **kwargs,
+        )
+        res["method"] = cls.tag
+        return res
+
+    @classmethod
+    def is_usable(cls, endpoint_context, request=None, authorization_token=None):
         """
         Verify that this authentication method is applicable.
 
         :param request: The request
-        :param authorization_info: Other authorization information
+        :param authorization_token: The authorization token
         :return: True/False
         """
         raise NotImplementedError()
@@ -76,7 +87,7 @@ class ClientAuthnMethod(object):
 
 def basic_authn(authorization_token):
     if not authorization_token.startswith("Basic "):
-        raise AuthnFailure("Wrong type of authorization token")
+        raise ClientAuthenticationError("Wrong type of authorization token")
 
     _tok = as_bytes(authorization_token[6:])
     # Will raise ValueError type exception if not base64 encoded
@@ -88,6 +99,25 @@ def basic_authn(authorization_token):
         raise ValueError("Illegal token")
 
 
+class NoneAuthn(ClientAuthnMethod):
+    """
+    Used for public clients, that don't require any form of authentication other
+    than their client_id
+    """
+
+    tag = "none"
+
+    @classmethod
+    def is_usable(cls, endpoint_context, request=None, authorization_token=None):
+        return request and "client_id" in request
+
+    @classmethod
+    def _verify(
+        cls, endpoint_context, request=None, authorization_token=None, endpoint=None, **kwargs
+    ):
+        return {"client_id": request["client_id"]}
+
+
 class ClientSecretBasic(ClientAuthnMethod):
     """
     Clients that have received a client_secret value from the Authorization
@@ -97,21 +127,22 @@ class ClientSecretBasic(ClientAuthnMethod):
 
     tag = "client_secret_basic"
 
-    def is_usable(self, request=None, authorization_token=None):
+    @classmethod
+    def is_usable(cls, endpoint_context, request=None, authorization_token=None):
         if authorization_token is not None and authorization_token.startswith("Basic "):
             return True
         return False
 
-    def verify(self, authorization_token, **kwargs):
+    @classmethod
+    def _verify(
+        cls, endpoint_context, request=None, authorization_token=None, endpoint=None, **kwargs
+    ):
         client_info = basic_authn(authorization_token)
 
-        if (
-            self.server_get("endpoint_context").cdb[client_info["id"]]["client_secret"]
-            == client_info["secret"]
-        ):
+        if endpoint_context.cdb[client_info["id"]]["client_secret"] == client_info["secret"]:
             return {"client_id": client_info["id"]}
         else:
-            raise AuthnFailure()
+            raise ClientAuthenticationError()
 
 
 class ClientSecretPost(ClientSecretBasic):
@@ -124,21 +155,22 @@ class ClientSecretPost(ClientSecretBasic):
 
     tag = "client_secret_post"
 
-    def is_usable(self, request=None, authorization_token=None):
+    @classmethod
+    def is_usable(cls, endpoint_context, request=None, authorization_token=None):
         if request is None:
             return False
         if "client_id" in request and "client_secret" in request:
             return True
         return False
 
-    def verify(self, request, **kwargs):
-        if (
-            self.server_get("endpoint_context").cdb[request["client_id"]]["client_secret"]
-            == request["client_secret"]
-        ):
+    @classmethod
+    def _verify(
+        cls, endpoint_context, request=None, authorization_token=None, endpoint=None, **kwargs
+    ):
+        if endpoint_context.cdb[request["client_id"]]["client_secret"] == request["client_secret"]:
             return {"client_id": request["client_id"]}
         else:
-            raise AuthnFailure("secrets doesn't match")
+            raise ClientAuthenticationError("secrets doesn't match")
 
 
 class BearerHeader(ClientSecretBasic):
@@ -146,13 +178,30 @@ class BearerHeader(ClientSecretBasic):
 
     tag = "bearer_header"
 
-    def is_usable(self, request=None, authorization_token=None):
+    @classmethod
+    def is_usable(cls, endpoint_context, request=None, authorization_token=None):
         if authorization_token is not None and authorization_token.startswith("Bearer "):
             return True
         return False
 
-    def verify(self, authorization_token, **kwargs):
-        return {"token": authorization_token.split(" ", 1)[1]}
+    @classmethod
+    def _verify(
+        cls,
+        endpoint_context,
+        request=None,
+        authorization_token=None,
+        endpoint=None,
+        get_client_id_from_token=None,
+        **kwargs,
+    ):
+        token = authorization_token.split(" ", 1)[1]
+        try:
+            client_id = get_client_id_from_token(endpoint_context, token, request)
+        except ToOld:
+            raise BearerTokenAuthenticationError("Expired token")
+        except KeyError:
+            raise BearerTokenAuthenticationError("Unknown token")
+        return {"token": token, "client_id": client_id}
 
 
 class BearerBody(ClientSecretPost):
@@ -162,15 +211,19 @@ class BearerBody(ClientSecretPost):
 
     tag = "bearer_body"
 
-    def is_usable(self, request=None, authorization_token=None):
+    @classmethod
+    def is_usable(cls, endpoint_context, request=None, authorization_token=None):
         if request is not None and "access_token" in request:
             return True
         return False
 
-    def verify(self, request, **kwargs):
+    @classmethod
+    def _verify(
+        cls, endpoint_context, request=None, authorization_token=None, endpoint=None, **kwargs
+    ):
         _token = request.get("access_token")
         if _token is None:
-            raise AuthnFailure("No access token")
+            raise ClientAuthenticationError("No access token")
 
         res = {"token": _token}
         _client_id = request.get("client_id")
@@ -180,28 +233,31 @@ class BearerBody(ClientSecretPost):
 
 
 class JWSAuthnMethod(ClientAuthnMethod):
-    def is_usable(self, request=None, authorization_token=None):
+    @classmethod
+    def is_usable(cls, endpoint_context, request=None, authorization_token=None):
         if request is None:
             return False
         if "client_assertion" in request:
             return True
         return False
 
-    def verify(self, request, key_type, **kwargs):
-        _context = self.server_get("endpoint_context")
-        _jwt = JWT(_context.keyjar, msg_cls=JsonWebToken)
+    @classmethod
+    def _verify(cls, endpoint_context, request=None, endpoint=None, key_type=None, **kwargs):
+        _jwt = JWT(endpoint_context.keyjar, msg_cls=JsonWebToken)
         try:
             ca_jwt = _jwt.unpack(request["client_assertion"])
         except (Invalid, MissingKey, BadSignature) as err:
             logger.info("%s" % sanitize(err))
-            raise AuthnFailure("Could not verify client_assertion.")
+            raise ClientAuthenticationError("Could not verify client_assertion.")
 
         _sign_alg = ca_jwt.jws_header.get("alg")
         if _sign_alg and _sign_alg.startswith("HS"):
             if key_type == "private_key":
                 raise AttributeError("Wrong key type")
-            keys = _context.keyjar.get("sig", "oct", ca_jwt["iss"], ca_jwt.jws_header.get("kid"))
-            _secret = _context.cdb[ca_jwt["iss"]].get("client_secret")
+            keys = endpoint_context.keyjar.get(
+                "sig", "oct", ca_jwt["iss"], ca_jwt.jws_header.get("kid")
+            )
+            _secret = endpoint_context.cdb[ca_jwt["iss"]].get("client_secret")
             if _secret and keys[0].key != as_bytes(_secret):
                 raise AttributeError("Oct key used for signing not client_secret")
         else:
@@ -211,26 +267,25 @@ class JWSAuthnMethod(ClientAuthnMethod):
         authtoken = sanitize(ca_jwt.to_dict())
         logger.debug("authntoken: {}".format(authtoken))
 
-        _endpoint = kwargs.get("endpoint")
-        if _endpoint is None or not _endpoint:
-            if _context.issuer in ca_jwt["aud"]:
+        if endpoint is None or not endpoint:
+            if endpoint_context.issuer in ca_jwt["aud"]:
                 pass
             else:
-                raise NotForMe("Not for me!")
+                raise InvalidToken("Not for me!")
         else:
-            if set(ca_jwt["aud"]).intersection(_endpoint.allowed_target_uris()):
+            if set(ca_jwt["aud"]).intersection(endpoint.allowed_target_uris()):
                 pass
             else:
-                raise NotForMe("Not for me!")
+                raise InvalidToken("Not for me!")
 
         # If there is a jti use it to make sure one-time usage is true
         _jti = ca_jwt.get("jti")
         if _jti:
             _key = "{}:{}".format(ca_jwt["iss"], _jti)
-            if _key in _context.jti_db:
-                raise MultipleUsage("Have seen this token once before")
+            if _key in endpoint_context.jti_db:
+                raise InvalidToken("Have seen this token once before")
             else:
-                _context.jti_db[_key] = utc_time_sans_frac()
+                endpoint_context.jti_db[_key] = utc_time_sans_frac()
 
         request[verified_claim_name("client_assertion")] = ca_jwt
         client_id = kwargs.get("client_id") or ca_jwt["iss"]
@@ -248,10 +303,12 @@ class ClientSecretJWT(JWSAuthnMethod):
 
     tag = "client_secret_jwt"
 
-    def verify(self, request=None, **kwargs):
-        res = JWSAuthnMethod.verify(self, request, key_type="client_secret", **kwargs)
+    @classmethod
+    def _verify(cls, endpoint_context, request=None, **kwargs):
+        res = JWSAuthnMethod.verify(
+            endpoint_context, request=request, key_type="client_secret", **kwargs
+        )
         # Verify that a HS alg was used
-        res["method"] = self.tag
         return res
 
 
@@ -262,37 +319,40 @@ class PrivateKeyJWT(JWSAuthnMethod):
 
     tag = "private_key_jwt"
 
-    def verify(self, request=None, **kwargs):
-        res = JWSAuthnMethod.verify(self, request, key_type="private_key", **kwargs)
+    @classmethod
+    def _verify(cls, endpoint_context, request=None, **kwargs):
+        res = JWSAuthnMethod.verify(
+            endpoint_context, request=request, key_type="private_key", **kwargs
+        )
         # Verify that an RS or ES alg was used ?
-        res["method"] = self.tag
         return res
 
 
 class RequestParam(ClientAuthnMethod):
     tag = "request_param"
 
-    def is_usable(self, request=None, authorization_info=None):
+    @classmethod
+    def is_usable(cls, endpoint_context, request=None, authorization_token=None):
         if request and "request" in request:
             return True
 
-    def verify(self, request=None, **kwargs):
-        _context = self.server_get("endpoint_context")
-        _jwt = JWT(_context.keyjar, msg_cls=JsonWebToken)
+    @classmethod
+    def _verify(cls, endpoint_context, request=None, **kwargs):
+        _jwt = JWT(endpoint_context.keyjar, msg_cls=JsonWebToken)
         try:
             _jwt = _jwt.unpack(request["request"])
         except (Invalid, MissingKey, BadSignature) as err:
             logger.info("%s" % sanitize(err))
-            raise AuthnFailure("Could not verify client_assertion.")
+            raise ClientAuthenticationError("Could not verify client_assertion.")
 
         # If there is a jti use it to make sure one-time usage is true
         _jti = _jwt.get("jti")
         if _jti:
             _key = "{}:{}".format(_jwt["iss"], _jti)
-            if _key in _context.jti_db:
-                raise MultipleUsage("Have seen this token once before")
+            if _key in endpoint_context.jti_db:
+                raise InvalidToken("Have seen this token once before")
             else:
-                _context.jti_db[_key] = utc_time_sans_frac()
+                endpoint_context.jti_db[_key] = utc_time_sans_frac()
 
         request[verified_claim_name("client_assertion")] = _jwt
         client_id = kwargs.get("client_id") or _jwt["iss"]
@@ -300,16 +360,17 @@ class RequestParam(ClientAuthnMethod):
         return {"client_id": client_id, "jwt": _jwt}
 
 
-CLIENT_AUTHN_METHOD = {
-    "client_secret_basic": ClientSecretBasic,
-    "client_secret_post": ClientSecretPost,
-    "bearer_header": BearerHeader,
-    "bearer_body": BearerBody,
-    "client_secret_jwt": ClientSecretJWT,
-    "private_key_jwt": PrivateKeyJWT,
-    "request_param": RequestParam,
-    "none": None,
-}
+# We use OrderedDict in order to ensure that the `none` method is used last
+CLIENT_AUTHN_METHOD = OrderedDict(
+    client_secret_basic=ClientSecretBasic,
+    client_secret_post=ClientSecretPost,
+    bearer_header=BearerHeader,
+    bearer_body=BearerBody,
+    client_secret_jwt=ClientSecretJWT,
+    private_key_jwt=PrivateKeyJWT,
+    request_param=RequestParam,
+    none=NoneAuthn,
+)
 
 TYPE_METHOD = [(JWT_BEARER, JWSAuthnMethod)]
 
@@ -348,30 +409,28 @@ def verify_client(
         authorization_token = None
 
     auth_info = {}
-    _methods = getattr(endpoint, "client_authn_method", [])
+    allowed_methods = getattr(endpoint, "client_authn_method")
+    if not allowed_methods:
+        allowed_methods = list(CLIENT_AUTHN_METHOD.keys())
 
-    for _method in _methods:
-        if _method is None:
+    for _method in (CLIENT_AUTHN_METHOD[meth] for meth in allowed_methods):
+        if not _method.is_usable(
+            endpoint_context, request=request, authorization_token=authorization_token
+        ):
             continue
-        if _method.is_usable(request, authorization_token):
-            try:
-                auth_info = _method.verify(
-                    request=request,
-                    authorization_token=authorization_token,
-                    endpoint=endpoint,
-                )
-            except Exception as err:
-                logger.warning("Verifying auth using {} failed: {}".format(_method.tag, err))
-            else:
-                if "method" not in auth_info:
-                    auth_info["method"] = _method.tag
-                break
-
-    if not auth_info:
-        if None in _methods:
-            auth_info = {"method": "none", "client_id": request.get("client_id")}
-        else:
-            return auth_info
+        try:
+            auth_info = _method.verify(
+                endpoint_context,
+                request=request,
+                authorization_token=authorization_token,
+                endpoint=endpoint,
+                get_client_id_from_token=get_client_id_from_token,
+            )
+            break
+        except (BearerTokenAuthenticationError, ClientAuthenticationError):
+            raise
+        except Exception as err:
+            logger.info("Verifying auth using {} failed: {}".format(_method.tag, err))
 
     if also_known_as:
         client_id = also_known_as[auth_info.get("client_id")]
@@ -379,58 +438,34 @@ def verify_client(
     else:
         client_id = auth_info.get("client_id")
 
-    _token = auth_info.get("token")
+    if client_id not in endpoint_context.cdb:
+        raise UnknownClient("Unknown Client ID")
 
-    if client_id:
-        if client_id not in endpoint_context.cdb:
-            raise UnknownClient("Unknown Client ID")
+    _cinfo = endpoint_context.cdb[client_id]
 
-        _cinfo = endpoint_context.cdb[client_id]
-        if isinstance(_cinfo, str):
-            if _cinfo not in endpoint_context.cdb:
-                raise UnknownClient("Unknown Client ID")
+    if not valid_client_info(_cinfo):
+        logger.warning("Client registration has timed out or " "client secret is expired.")
+        raise InvalidClient("Not valid client")
 
-        if not valid_client_info(_cinfo):
-            logger.warning("Client registration has timed out or " "client secret is expired.")
-            raise InvalidClient("Not valid client")
+    # Validate that the used method is allowed for this client/endpoint
+    client_allowed_methods = _cinfo.get(f"{endpoint.endpoint_name}_client_authn_method")
+    if client_allowed_methods is not None and _method.tag not in client_allowed_methods:
+        logger.info(
+            f"Allowed methods for client: {client_id} at endpoint: {endpoint.name} are: "
+            f"`{', '.join(client_allowed_methods)}`"
+        )
+        raise UnAuthorizedClient(
+            f"Authentication method: {_method.tag} not allowed for client: {client_id} in "
+            f"endpoint: {endpoint.name}"
+        )
 
-        # store what authn method was used
-        if auth_info.get("method"):
-            _request_type = request.__class__.__name__
-            _used_authn_method = endpoint_context.cdb[client_id].get("auth_method")
-            if _used_authn_method:
-                endpoint_context.cdb[client_id]["auth_method"][_request_type] = auth_info["method"]
-            else:
-                endpoint_context.cdb[client_id]["auth_method"] = {
-                    _request_type: auth_info["method"]
-                }
-    elif not client_id and get_client_id_from_token:
-        if not _token:
-            logger.warning("No token")
-            raise BearerTokenAuthenticationError("No token")
-
-        try:
-            # get_client_id_from_token is a callback... Do not abuse for code readability.
-            auth_info["client_id"] = get_client_id_from_token(endpoint_context, _token, request)
-        except ToOld:
-            raise BearerTokenAuthenticationError("Expired token")
-        except KeyError:
-            raise BearerTokenAuthenticationError("Unknown token")
+    # store what authn method was used
+    if auth_info.get("method"):
+        _request_type = request.__class__.__name__
+        _used_authn_method = _cinfo.get("auth_method")
+        if _used_authn_method:
+            endpoint_context.cdb[client_id]["auth_method"][_request_type] = auth_info["method"]
+        else:
+            endpoint_context.cdb[client_id]["auth_method"] = {_request_type: auth_info["method"]}
 
     return auth_info
-
-
-def client_auth_setup(auth_set, server_get):
-    res = []
-
-    for item in auth_set:
-        if item is None or item.lower() == "none":
-            res.append(None)
-        else:
-            _cls = CLIENT_AUTHN_METHOD.get(item)
-            if _cls:
-                res.append(_cls(server_get))
-            else:
-                res.append(importer(item)(server_get))
-
-    return res

--- a/src/oidcop/endpoint.py
+++ b/src/oidcop/endpoint.py
@@ -12,7 +12,6 @@ from oidcmsg.oauth2 import ResponseMessage
 from oidcmsg.oidc import RegistrationRequest
 
 from oidcop import sanitize
-from oidcop.client_authn import client_auth_setup
 from oidcop.client_authn import verify_client
 from oidcop.construct import construct_endpoint_info
 from oidcop.endpoint_context import EndpointContext
@@ -115,13 +114,11 @@ class Endpoint(object):
         _methods = kwargs.get("client_authn_method")
         self.client_authn_method = []
         if _methods:
-            self.client_authn_method = client_auth_setup(_methods, server_get)
+            self.client_authn_method = _methods
         elif _methods is not None:  # [] or '' or something not None but regarded as nothing.
-            self.client_authn_method = [None]  # Ignore default value
+            self.client_authn_method = ["none"]  # Ignore default value
         elif self.default_capabilities:
-            _methods = self.default_capabilities.get("client_authn_method")
-            if _methods:
-                self.client_authn_method = client_auth_setup(_methods, server_get)
+            self.client_authn_method = self.default_capabilities.get("client_authn_method")
         self.endpoint_info = construct_endpoint_info(self.default_capabilities, **kwargs)
 
         # This is for matching against aud in JWTs

--- a/src/oidcop/endpoint_context.py
+++ b/src/oidcop/endpoint_context.py
@@ -116,6 +116,7 @@ class EndpointContext(OidcContext):
         "symkey": "",
         "token_args_methods": [],
         # "userinfo": UserInfo,
+        "client_authn_method": {},
     }
 
     def __init__(
@@ -169,6 +170,7 @@ class EndpointContext(OidcContext):
         self.template_handler = None
         self.token_args_methods = []
         self.userinfo = None
+        self.client_authn_method = {}
 
         for param in [
             "issuer",

--- a/src/oidcop/exception.py
+++ b/src/oidcop/exception.py
@@ -70,6 +70,10 @@ class InvalidClient(ClientAuthenticationError):
     pass
 
 
+class InvalidToken(ClientAuthenticationError):
+    pass
+
+
 class UnAuthorizedClient(ClientAuthenticationError):
     pass
 

--- a/src/oidcop/oauth2/add_on/dpop.py
+++ b/src/oidcop/oauth2/add_on/dpop.py
@@ -9,9 +9,9 @@ from oidcmsg.message import SINGLE_REQUIRED_JSON
 from oidcmsg.message import SINGLE_REQUIRED_STRING
 from oidcmsg.message import Message
 
-from oidcop.client_authn import AuthnFailure
 from oidcop.client_authn import ClientAuthnMethod
 from oidcop.client_authn import basic_authn
+from oidcop.exception import ClientAuthenticationError
 
 
 class DPoPProof(Message):
@@ -167,4 +167,4 @@ class DPoPClientAuth(ClientAuthnMethod):
         if _context.cdb[client_info["id"]]["client_secret"] == client_info["secret"]:
             return {"client_id": client_info["id"]}
         else:
-            raise AuthnFailure()
+            raise ClientAuthenticationError()

--- a/src/oidcop/oauth2/authorization.py
+++ b/src/oidcop/oauth2/authorization.py
@@ -286,6 +286,7 @@ class Authorization(Endpoint):
     name = "authorization"
     default_capabilities = {
         "claims_parameter_supported": True,
+        "client_authn_method": ["request_param", "none"],
         "request_parameter_supported": True,
         "request_uri_parameter_supported": True,
         "response_types_supported": ["code", "token", "code token"],

--- a/src/oidcop/oauth2/authorization.py
+++ b/src/oidcop/oauth2/authorization.py
@@ -286,7 +286,7 @@ class Authorization(Endpoint):
     name = "authorization"
     default_capabilities = {
         "claims_parameter_supported": True,
-        "client_authn_method": ["request_param", "none"],
+        "client_authn_method": ["request_param", "public"],
         "request_parameter_supported": True,
         "request_uri_parameter_supported": True,
         "response_types_supported": ["code", "token", "code token"],

--- a/src/oidcop/oauth2/introspection.py
+++ b/src/oidcop/oauth2/introspection.py
@@ -20,6 +20,14 @@ class Introspection(Endpoint):
     response_format = "json"
     endpoint_name = "introspection_endpoint"
     name = "introspection"
+    default_capabilities = {
+        "client_authn_method": [
+            "client_secret_basic",
+            "client_secret_post",
+            "client_secret_jwt",
+            "private_key_jwt",
+        ]
+    }
 
     def __init__(self, server_get, **kwargs):
         Endpoint.__init__(self, server_get, **kwargs)

--- a/src/oidcop/oidc/authorization.py
+++ b/src/oidcop/oidc/authorization.py
@@ -77,7 +77,7 @@ class Authorization(authorization.Authorization):
     name = "authorization"
     default_capabilities = {
         "claims_parameter_supported": True,
-        "client_authn_method": ["request_param", "none"],
+        "client_authn_method": ["request_param", "public"],
         "request_parameter_supported": True,
         "request_uri_parameter_supported": True,
         "response_types_supported": [

--- a/src/oidcop/oidc/authorization.py
+++ b/src/oidcop/oidc/authorization.py
@@ -77,6 +77,7 @@ class Authorization(authorization.Authorization):
     name = "authorization"
     default_capabilities = {
         "claims_parameter_supported": True,
+        "client_authn_method": ["request_param", "none"],
         "request_parameter_supported": True,
         "request_uri_parameter_supported": True,
         "response_types_supported": [

--- a/src/oidcop/oidc/session.py
+++ b/src/oidcop/oidc/session.py
@@ -25,7 +25,6 @@ from oidcmsg.oidc.session import BACK_CHANNEL_LOGOUT_EVENT
 from oidcmsg.oidc.session import EndSessionRequest
 
 from oidcop import rndstr
-from oidcop.client_authn import UnknownOrNoAuthnMethod
 from oidcop.endpoint import Endpoint
 from oidcop.endpoint_context import add_path
 from oidcop.oauth2.authorization import verify_uri
@@ -361,18 +360,14 @@ class Session(Endpoint):
             request = {}
 
         # Verify that the client is allowed to do this
-        try:
-            auth_info = self.client_authentication(request, http_info, **kwargs)
-        except UnknownOrNoAuthnMethod:
+        auth_info = self.client_authentication(request, http_info, **kwargs)
+        if not auth_info:
             pass
+        elif isinstance(auth_info, ResponseMessage):
+            return auth_info
         else:
-            if not auth_info:
-                pass
-            elif isinstance(auth_info, ResponseMessage):
-                return auth_info
-            else:
-                request["client_id"] = auth_info["client_id"]
-                request["access_token"] = auth_info["token"]
+            request["client_id"] = auth_info["client_id"]
+            request["access_token"] = auth_info["token"]
 
         if isinstance(request, dict):
             _context = self.server_get("endpoint_context")

--- a/src/oidcop/oidc/userinfo.py
+++ b/src/oidcop/oidc/userinfo.py
@@ -13,7 +13,7 @@ from oidcmsg.message import Message
 from oidcmsg.oauth2 import ResponseMessage
 
 from oidcop.endpoint import Endpoint
-from oidcop.token.exception import UnknownToken
+from oidcop.exception import ClientAuthenticationError
 from oidcop.util import OAUTH2_NOCACHE_HEADERS
 
 logger = logging.getLogger(__name__)
@@ -172,7 +172,7 @@ class UserInfo(Endpoint):
         # Verify that the client is allowed to do this
         try:
             auth_info = self.client_authentication(request, http_info, **kwargs)
-        except (ValueError, UnknownToken) as e:
+        except ClientAuthenticationError as e:
             return self.error_cls(error="invalid_token", error_description=e.args[0])
 
         if isinstance(auth_info, ResponseMessage):

--- a/src/oidcop/server.py
+++ b/src/oidcop/server.py
@@ -6,7 +6,6 @@ from cryptojwt import KeyJar
 from oidcmsg.impexp import ImpExp
 
 from oidcop import authz
-from oidcop.client_authn import client_auth_setup
 from oidcop.configure import ASConfiguration
 from oidcop.configure import OPConfiguration
 from oidcop.endpoint import Endpoint
@@ -94,23 +93,8 @@ class Server(ImpExp):
         # Must be done after userinfo
         self.do_login_hint_lookup()
 
-        for endpoint_name, endpoint_conf in self.endpoint.items():
-            _endpoint = self.endpoint[endpoint_name]
-            _methods = _endpoint.kwargs.get("client_authn_method")
-
-            self.client_authn_method = []
-            if _methods:
-                _endpoint.client_authn_method = client_auth_setup(_methods, self.server_get)
-            elif _methods is not None:  # [] or '' or something not None but regarded as nothing.
-                _endpoint.client_authn_method = [None]  # Ignore default value
-            elif _endpoint.default_capabilities:
-                _methods = _endpoint.default_capabilities.get("client_authn_method")
-                if _methods:
-                    _endpoint.client_authn_method = client_auth_setup(
-                        auth_set=_methods, server_get=self.server_get
-                    )
-
-            _endpoint.server_get = self.server_get
+        for endpoint_name, _ in self.endpoint.items():
+            self.endpoint[endpoint_name].server_get = self.server_get
 
         _token_endp = self.endpoint.get("token")
         if _token_endp:

--- a/src/oidcop/server.py
+++ b/src/oidcop/server.py
@@ -8,6 +8,7 @@ from oidcmsg.impexp import ImpExp
 from oidcop import authz
 from oidcop.configure import ASConfiguration
 from oidcop.configure import OPConfiguration
+from oidcop.client_authn import client_auth_setup
 from oidcop.endpoint import Endpoint
 from oidcop.endpoint_context import EndpointContext
 from oidcop.endpoint_context import init_service
@@ -93,6 +94,7 @@ class Server(ImpExp):
         # Must be done after userinfo
         self.do_login_hint_lookup()
 
+        self.do_client_authn_methods()
         for endpoint_name, _ in self.endpoint.items():
             self.endpoint[endpoint_name].server_get = self.server_get
 
@@ -166,3 +168,6 @@ class Server(ImpExp):
 
             self.endpoint_context.login_hint_lookup = init_service(_conf)
             self.endpoint_context.login_hint_lookup.userinfo = _userinfo
+
+    def do_client_authn_methods(self):
+        self.endpoint_context.client_authn_method = client_auth_setup(self.server_get, self.conf.get("client_authn_method"))

--- a/tests/test_20_endpoint.py
+++ b/tests/test_20_endpoint.py
@@ -17,7 +17,7 @@ KEYDEFS = [
     {"type": "EC", "crv": "P-256", "use": ["sig"]},
 ]
 
-REQ = Message(foo="bar", hej="hopp")
+REQ = Message(foo="bar", hej="hopp", client_id="client_id")
 
 EXAMPLE_MSG = {
     "name": "Jane Doe",
@@ -65,6 +65,7 @@ class TestEndpoint(object):
         }
         server = Server(OPConfiguration(conf=conf, base_path=BASEDIR), cwd=BASEDIR)
 
+        server.endpoint_context.cdb["client_id"] = {}
         self.endpoint_context = server.endpoint_context
         self.endpoint = server.server_get("endpoint", "")
 

--- a/tests/test_23_oidc_registration_endpoint.py
+++ b/tests/test_23_oidc_registration_endpoint.py
@@ -45,6 +45,7 @@ RESPONSE_TYPES_SUPPORTED = [
 ]
 
 MSG = {
+    "client_id": "client_id",
     "application_type": "web",
     "redirect_uris": [
         "https://client.example.org/callback",
@@ -152,6 +153,7 @@ class TestEndpoint(object):
             "template_dir": "template",
         }
         server = Server(OPConfiguration(conf=conf, base_path=BASEDIR), cwd=BASEDIR)
+        server.endpoint_context.cdb["client_id"] = {}
         self.endpoint = server.server_get("endpoint", "registration")
 
     def test_parse(self):

--- a/tests/test_24_oauth2_token_endpoint.py
+++ b/tests/test_24_oauth2_token_endpoint.py
@@ -15,7 +15,7 @@ from oidcop.authn_event import create_authn_event
 from oidcop.authz import AuthzHandling
 from oidcop.client_authn import verify_client
 from oidcop.configure import ASConfiguration
-from oidcop.exception import UnAuthorizedClient
+from oidcop.exception import InvalidToken
 from oidcop.oauth2.authorization import Authorization
 from oidcop.oauth2.token import Token
 from oidcop.server import Server
@@ -320,7 +320,7 @@ class TestEndpoint(object):
         _resp = self.token_endpoint.process_request(request=_req)
 
         # 2nd time used
-        with pytest.raises(UnAuthorizedClient):
+        with pytest.raises(InvalidToken):
             self.token_endpoint.parse_request(_token_request)
 
     def test_do_refresh_access_token(self):

--- a/tests/test_26_oidc_userinfo_endpoint.py
+++ b/tests/test_26_oidc_userinfo_endpoint.py
@@ -565,7 +565,8 @@ class TestEndpoint(object):
         code = self._mint_code(grant, session_id)
         access_token = self._mint_token("access_token", grant, session_id, code)
 
-        _req = self.endpoint.parse_request({"access_token": access_token.value})
+        http_info = {"headers": {"authorization": "Bearer {}".format(access_token.value)}}
+        _req = self.endpoint.parse_request({}, http_info=http_info)
         args = self.endpoint.process_request(_req)
         assert args
         res = self.endpoint.do_response(request=_req, **args)

--- a/tests/test_30_oidc_end_session.py
+++ b/tests/test_30_oidc_end_session.py
@@ -288,8 +288,7 @@ class TestEndpoint(object):
         _session_info = self.session_manager.get_session_info_by_token(_code)
         cookie = self._create_cookie(_session_info["session_id"])
         http_info = {"cookie": [cookie]}
-        _req_args = self.session_endpoint.parse_request({"state": "1234567"}, http_info=http_info)
-        resp = self.session_endpoint.process_request(_req_args, http_info=http_info)
+        resp = self.session_endpoint.process_request({"state": "foo"}, http_info=http_info)
 
         # returns a signed JWT to be put in a verification web page shown to
         # the user

--- a/tests/test_31_oauth2_introspection.py
+++ b/tests/test_31_oauth2_introspection.py
@@ -18,7 +18,7 @@ from oidcmsg.time_util import utc_time_sans_frac
 from oidcop.authn_event import create_authn_event
 from oidcop.authz import AuthzHandling
 from oidcop.client_authn import verify_client
-from oidcop.exception import UnAuthorizedClient
+from oidcop.exception import UnknownClient
 from oidcop.oauth2.authorization import Authorization
 from oidcop.oauth2.introspection import Introspection
 from oidcop.oidc.token import Token
@@ -240,7 +240,7 @@ class TestEndpoint:
 
     def test_parse_no_authn(self):
         access_token = self._get_access_token(AUTH_REQ)
-        with pytest.raises(UnAuthorizedClient):
+        with pytest.raises(UnknownClient):
             self.introspection_endpoint.parse_request({"token": access_token.value})
 
     def test_parse_with_client_auth_in_req(self):
@@ -271,7 +271,7 @@ class TestEndpoint:
         _basic_authz = "Basic {}".format(_basic_token)
         http_info = {"headers": {"authorization": _basic_authz}}
 
-        with pytest.raises(UnAuthorizedClient):
+        with pytest.raises(UnknownClient):
             self.introspection_endpoint.parse_request(
                 {"token": access_token.value}, http_info=http_info
             )

--- a/tests/test_31_oauth2_introspection.py
+++ b/tests/test_31_oauth2_introspection.py
@@ -18,7 +18,7 @@ from oidcmsg.time_util import utc_time_sans_frac
 from oidcop.authn_event import create_authn_event
 from oidcop.authz import AuthzHandling
 from oidcop.client_authn import verify_client
-from oidcop.exception import UnknownClient
+from oidcop.exception import ClientAuthenticationError
 from oidcop.oauth2.authorization import Authorization
 from oidcop.oauth2.introspection import Introspection
 from oidcop.oidc.token import Token
@@ -240,7 +240,7 @@ class TestEndpoint:
 
     def test_parse_no_authn(self):
         access_token = self._get_access_token(AUTH_REQ)
-        with pytest.raises(UnknownClient):
+        with pytest.raises(ClientAuthenticationError):
             self.introspection_endpoint.parse_request({"token": access_token.value})
 
     def test_parse_with_client_auth_in_req(self):
@@ -271,7 +271,7 @@ class TestEndpoint:
         _basic_authz = "Basic {}".format(_basic_token)
         http_info = {"headers": {"authorization": _basic_authz}}
 
-        with pytest.raises(UnknownClient):
+        with pytest.raises(ClientAuthenticationError):
             self.introspection_endpoint.parse_request(
                 {"token": access_token.value}, http_info=http_info
             )

--- a/tests/test_32_oidc_read_registration.py
+++ b/tests/test_32_oidc_read_registration.py
@@ -48,6 +48,7 @@ CAPABILITIES = {
 }
 
 msg = {
+    "client_id": "client_1",
     "application_type": "web",
     "redirect_uris": [
         "https://client.example.org/callback",
@@ -117,6 +118,7 @@ class TestEndpoint(object):
         server = Server(OPConfiguration(conf=conf, base_path=BASEDIR), cwd=BASEDIR)
         self.registration_endpoint = server.server_get("endpoint", "registration")
         self.registration_api_endpoint = server.server_get("endpoint", "registration_read")
+        server.endpoint_context.cdb["client_1"] = {}
 
     def test_do_response(self):
         _req = self.registration_endpoint.parse_request(CLI_REQ.to_json())

--- a/tests/test_35_oidc_token_endpoint.py
+++ b/tests/test_35_oidc_token_endpoint.py
@@ -18,7 +18,7 @@ from oidcop.authz import AuthzHandling
 from oidcop.client_authn import verify_client
 from oidcop.configure import OPConfiguration
 from oidcop.cookie_handler import CookieHandler
-from oidcop.exception import UnAuthorizedClient
+from oidcop.exception import InvalidToken
 from oidcop.oidc import userinfo
 from oidcop.oidc.authorization import Authorization
 from oidcop.oidc.provider_config import ProviderConfiguration
@@ -334,7 +334,7 @@ class TestEndpoint(_TestEndpoint):
         _resp = self.token_endpoint.process_request(request=_req)
 
         # 2nd time used
-        with pytest.raises(UnAuthorizedClient):
+        with pytest.raises(InvalidToken):
             self.token_endpoint.parse_request(_token_request)
 
     def test_do_refresh_access_token(self):


### PR DESCRIPTION
This PR introduces various changes to the client authentication flow. I believe that with these changes the flow is cleaner. 
This PR changes:
- Add `client_authn_methods` per client and per endpoint.
- The `client_authn_methods` of a client MUST be a subset of the endpoint's `client_authn_methods`.
- Change `none` client_authn_method to require a client_id in the request. This may be breaking in the case of the session endpoint. Perhaps a different authn class is required there.
- Refactor raised errors.

TODO:
- [ ] Document client_authn_method per client
- [ ] Should we allow the `client_authn_methods` of a client to allow methods not allowed in the endpoint. The problem with implementing this is that we don't know the client before we authenticate it, which would force us to have some brute force approach that would check all the client authn methods, find one that works and then check that it is allowed for this client/endpoint, if not then we continue looking for a client authn method that works