### PR TITLE
Remove client_authn_method from provider

### DIFF
--- a/src/oidcop/server.py
+++ b/src/oidcop/server.py
@@ -37,7 +37,8 @@ def do_endpoints(conf, server_get):
 
 
 def get_capabilities(conf, endpoints):
-    _cap = conf.get("capabilities", {})
+    ignored_capabilities = ["client_authn_method"]
+    _cap = dict(conf.get("capabilities", {}))
     if _cap is None:
         _cap = {}
 
@@ -49,6 +50,10 @@ def get_capabilities(conf, endpoints):
             for key, val in endpoint_instance.endpoint_info.items():
                 if key not in _cap:
                     _cap[key] = val
+
+    for key in ignored_capabilities:
+        if key in _cap:
+            _cap.pop(key)
 
     return _cap
 

--- a/tests/test_22_oidc_provider_config_endpoint.py
+++ b/tests/test_22_oidc_provider_config_endpoint.py
@@ -6,6 +6,7 @@ import pytest
 from oidcop.configure import OPConfiguration
 from oidcop.oidc.provider_config import ProviderConfiguration
 from oidcop.oidc.token import Token
+from oidcop.oauth2.introspection import Introspection
 from oidcop.server import Server
 
 BASEDIR = os.path.abspath(os.path.dirname(__file__))
@@ -65,7 +66,8 @@ class TestEndpoint(object):
                     "class": ProviderConfiguration,
                     "kwargs": {},
                 },
-                "token": {"path": "token", "class": Token, "kwargs": {}},
+                "token": {"path": "token", "class": Token, "kwargs": {"client_authn_method": ["client_secret_basic"]}},
+                "introspection": {"path": "introspection", "class": Introspection, "kwargs": {"client_authn_method": ["client_secret_basic"]}},
             },
             "template_dir": "template",
         }
@@ -107,6 +109,7 @@ class TestEndpoint(object):
             "updated_at",
             "birthdate",
         }
+        assert "client_authn_method" not in _msg
         assert ("Content-type", "application/json; charset=utf-8") in msg["http_headers"]
 
     def test_scopes_supported(self, conf):


### PR DESCRIPTION
Remove the `client_authn_method` from the provider info endpoint. It is not described in the spec and it is pretty buggy, as each endpoint can over-write the methods of the other endpoints, which means that the result relies on the iteration order.

If we want to expose the client authentication methods supported for the other endpoints,  we should do it per endpoint, e.g. `introspection_endpoint_auth_methods_supported` (like `token_endpoint_auth_methods_supported`, which is the only one described in the discovery specification)