### PR TITLE
Fix introspection expired token exception

### DIFF
--- a/src/oidcop/oauth2/introspection.py
+++ b/src/oidcop/oauth2/introspection.py
@@ -7,6 +7,7 @@ from oidcmsg import oauth2
 from oidcop.endpoint import Endpoint
 from oidcop.token.exception import UnknownToken
 from oidcop.token.exception import WrongTokenClass
+from oidcop.exception import ToOld
 
 LOGGER = logging.getLogger(__name__)
 
@@ -104,7 +105,7 @@ class Introspection(Endpoint):
             _session_info = _context.session_manager.get_session_info_by_token(
                 request_token, grant=True
             )
-        except (UnknownToken, WrongTokenClass):
+        except (UnknownToken, WrongTokenClass, ToOld):
             return {"response_args": _resp}
 
         grant = _session_info["grant"]

--- a/tests/test_31_oauth2_introspection.py
+++ b/tests/test_31_oauth2_introspection.py
@@ -444,9 +444,14 @@ class TestEndpoint:
         _resp = self.introspection_endpoint.process_request(_req)
         assert _resp["response_args"]["active"] is False
 
-    def test_expired_access_token(self):
+    def test_expired_access_token(self, monkeypatch):
         access_token = self._get_access_token(AUTH_REQ)
-        access_token.expires_at = utc_time_sans_frac() - 1000
+        lifetime = self.session_manager.token_handler.handler["access_token"].lifetime
+
+        def mock():
+            return utc_time_sans_frac() + lifetime + 1
+
+        monkeypatch.setattr("oidcop.token.utc_time_sans_frac", mock)
 
         _context = self.introspection_endpoint.server_get("endpoint_context")
 


### PR DESCRIPTION
`get_session_info_by_token`'s call to `token_handler.info` may raise a `ToOld` exception if the token is a jwt.

In this PR we catch it and return `active=False`.